### PR TITLE
Reformat purl and add meta.source.name

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -93,10 +93,11 @@ public final class Util {
     public static String getArtifactIdentity(Run.Artifact artifact, String buildUrl, Integer buildNumber) {
         String identity;
         identity = "pkg:";
-        identity += buildUrl;
         identity += resolveArtifactPath(artifact.toString());
         identity += "@";
         identity += String.valueOf(buildNumber);
+        identity += "?build_path=";
+        identity += buildUrl;
 
         return identity;
     }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
@@ -43,6 +43,7 @@ import net.sf.json.JSONObject;
  * @author Isac Holm &lt;isac.holm@axis.com&gt;
  */
 abstract class EiffelEvent {
+    public final static String META_SOURCE_NAME = "JENKINS_EIFFEL_BROADCASTER";
 
     /**
     * EiffelEvent Constants.
@@ -89,10 +90,14 @@ abstract class EiffelEvent {
     * Constructor for EiffelEvent.
     */
     public EiffelEvent() {
+        HashMap<String, String> metaSourceMap = new HashMap<>();
+        metaSourceMap.put("name", META_SOURCE_NAME);
+
         eventMeta.put("id", Util.getUUID());
         eventMeta.put("time", Util.getTime());
         eventMeta.put("type", this.getClass().getSimpleName());
         eventMeta.put("version", getVersion());
+        eventMeta.put("source", metaSourceMap);
     }
     /**
     * Get this event as Json.


### PR DESCRIPTION
1) Reformat purl in data.identity to allow for easier parsing to extract the Jenkins build path
2) Add "JENKINS_EIFFEL_BROADCASTER" as meta.source.name to make it easier for other Eiffel actors to identify events coming from this plugin.