### PR TITLE
pom.xml: Upgrade findbugs-maven-plugin to fix build error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>findbugs-maven-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>3.0.5</version>
                 <configuration>
                     <xmlOutput>true</xmlOutput>
                     <excludeFilterFile>findbugs-exclude.xml</excludeFilterFile>


### PR DESCRIPTION
Maven 3.6 and findbugs-maven-plugin 3.0.1 results in the following error:

    [2020-02-29T20:52:59.072Z] [ERROR] Failed to execute goal org.codehaus.mojo:findbugs-maven-plugin:3.0.1:findbugs (findbugs) on project eiffel-broadcaster: Unable to parse configuration of mojo org.codehaus.mojo:findbugs-maven-plugin:3.0.1:findbugs for parameter pluginArtifacts: Cannot assign configuration entry 'pluginArtifacts' with value '${plugin.artifacts}' of type java.util.Collections.UnmodifiableRandomAccessList to property of type java.util.ArrayList -> [Help 1]

Guided by https://stackoverflow.com/a/55834783 the plugin is upgraded to the latest version.