### PR TITLE
Introduce tests of emitted events and fix a few bugs found along the way

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
         <amqp.client.version>4.8.0</amqp.client.version>
         <commons.lang3.version>3.11</commons.lang3.version>
         <commons.validator.version>1.7</commons.validator.version>
+        <jackson2-api.version>2.11.1</jackson2-api.version>
         <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
         <jmockit.version>1.41</jmockit.version>
     </properties>
@@ -68,6 +69,11 @@
             <groupId>commons-validator</groupId>
             <artifactId>commons-validator</artifactId>
             <version>${commons.validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jackson2-api</artifactId>
+            <version>${jackson2-api.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -150,7 +156,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>1.15</version>
+                <version>1.16</version>
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,8 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-        <version>2.37</version>
+        <version>4.15</version>
         <relativePath />
     </parent>
     <groupId>com.axis.jenkins.plugins.eiffel</groupId>
@@ -50,46 +49,15 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jmockit.version>1.5</jmockit.version>
-        <junit.version>4.13.1</junit.version>
+        <java.level>8</java.level>
+        <jenkins.version>2.164.3</jenkins.version>
+
         <amqp.client.version>4.8.0</amqp.client.version>
-        <commons.validator.version>1.4.0</commons.validator.version>
-        <commons.digester.version>2.1</commons.digester.version>
-        <commons.lang3.version>3.4</commons.lang3.version>
+        <commons.lang3.version>3.11</commons.lang3.version>
+        <commons.validator.version>1.7</commons.validator.version>
+        <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
     </properties>
     <dependencies>
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>2.2.6</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>jackson-coreutils</artifactId>
-            <version>1.8</version>
-        </dependency>
-        <dependency>
-            <groupId>com.github.fge</groupId>
-            <artifactId>json-schema-core</artifactId>
-            <version>1.2.5</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-digester</groupId>
-            <artifactId>commons-digester</artifactId>
-            <version>${commons.digester.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.googlecode.jmockit</groupId>
-            <artifactId>jmockit</artifactId>
-            <version>${jmockit.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>${junit.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>
@@ -104,16 +72,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>matrix-project</artifactId>
-            <version>1.4</version>
         </dependency>
     </dependencies>
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <commons.lang3.version>3.11</commons.lang3.version>
         <commons.validator.version>1.7</commons.validator.version>
         <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
+        <jmockit.version>1.41</jmockit.version>
     </properties>
     <dependencies>
         <dependency>
@@ -73,7 +74,49 @@
             <artifactId>commons-lang3</artifactId>
             <version>${commons.lang3.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-cps</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-job</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jmockit</groupId>
+            <artifactId>jmockit</artifactId>
+            <version>${jmockit.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.164.x</artifactId>
+                <version>10</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018-2020 Axis Communications AB.
+ Copyright 2018-2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -59,7 +59,7 @@ import java.net.URISyntaxException;
  */
 @Extension
 public final class EiffelBroadcasterConfig extends Plugin implements Describable<EiffelBroadcasterConfig> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(EiffelBroadcasterConfig.class);
+    private static final Logger logger = LoggerFactory.getLogger(EiffelBroadcasterConfig.class);
     private final String[] schemes = {"amqp", "amqps"};
     private static final String SERVER_URI = "serverUri";
     private static final String USERNAME = "userName";
@@ -119,7 +119,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
     @Override
     public void start() throws Exception {
         super.start();
-        LOGGER.info("Starting EiffelBroadcaster Plugin");
+        logger.info("Starting EiffelBroadcaster Plugin");
         load();
         MQConnection.getInstance().initialize(userName, userPassword, serverUri, virtualHost);
     }
@@ -225,7 +225,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
         if (jenkins != null) {
             return jenkins.getPlugin(EiffelBroadcasterConfig.class);
         } else {
-            LOGGER.error("Error, Jenkins could not be found, so no plugin!");
+            logger.error("Error, Jenkins could not be found, so no plugin!");
             return null;
         }
     }
@@ -387,7 +387,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
                     try {
                         conn.close();
                     } catch (IOException e) {
-                        LOGGER.warn("An error occurred when closing the AMQP connection", e);
+                        logger.warn("An error occurred when closing the AMQP connection", e);
                     }
                 }
             } else {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2018-2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import java.util.HashMap;
+import java.util.UUID;
 
 /**
  * Contains eiffel event map for jobs {@link EiffelJobTable}.
@@ -37,14 +38,14 @@ import java.util.HashMap;
  */
 public final class EiffelJobTable {
     private static EiffelJobTable instance = null;
-    private HashMap<Long, String> table;
+    private HashMap<Long, UUID> table;
 
     /**
      * EiffelJobTable Constructor.
      *
      */
      private EiffelJobTable() {
-        this.table = new HashMap<Long, String>();
+        this.table = new HashMap<Long, UUID>();
     }
 
     /**
@@ -62,7 +63,7 @@ public final class EiffelJobTable {
      * Get table HashMap method.
      * @return HashMap
      */
-    private HashMap<Long, String> getTable() {
+    private HashMap<Long, UUID> getTable() {
         return table;
     }
 
@@ -72,7 +73,7 @@ public final class EiffelJobTable {
      * @param jenkinsID
      * uniqe id of a jenkins job.
      */
-    public String getEventTrigger(Long jenkinsID) {
+    public UUID getEventTrigger(Long jenkinsID) {
         return getTable().get(jenkinsID);
     }
 
@@ -83,7 +84,7 @@ public final class EiffelJobTable {
      * @param eiffelEventID
      * uniqe id of an eiffel event.
      */
-    public void setEventTrigger(Long jenkinsID, String eiffelEventID) {
+    public void setEventTrigger(Long jenkinsID, UUID eiffelEventID) {
         getTable().put(jenkinsID, eiffelEventID);
     }
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2018-2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
 @Extension
 public class ItemListenerImpl extends ItemListener {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(ItemListenerImpl.class);
+    private static final Logger logger = LoggerFactory.getLogger(ItemListenerImpl.class);
 
     /**
      * Create instance.
@@ -49,7 +49,7 @@ public class ItemListenerImpl extends ItemListener {
 
     @Override
     public final void onLoaded() {
-        LOGGER.info("All jobs have been loaded.");
+        logger.info("All jobs have been loaded.");
         EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
         if (config != null && config.isBroadcasterEnabled()) {
             MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2018-2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -52,7 +52,7 @@ import java.util.concurrent.TimeoutException;
  * @author Isac Holm &lt;isac.holm@axis..com&gt;
  */
 public final class MQConnection implements ShutdownListener {
-    private static final Logger LOGGER = LoggerFactory.getLogger(MQConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(MQConnection.class);
     private static final int HEARTBEAT_INTERVAL = 30;
     private static final int MESSAGE_QUEUE_SIZE = 1000;
     private static final int SENDMESSAGE_TIMEOUT = 100;
@@ -178,12 +178,12 @@ public final class MQConnection implements ShutdownListener {
                 }
             }
             messageQueueThread.start();
-            LOGGER.info("messageQueueThread recreated since it was null or not alive.");
+            logger.info("messageQueueThread recreated since it was null or not alive.");
         }
 
         MessageData messageData = new MessageData(exchange, routingKey, props, body);
         if (!messageQueue.offer(messageData)) {
-            LOGGER.error("addMessageToQueue() failed, RabbitMQ queue is full!");
+            logger.error("addMessageToQueue() failed, RabbitMQ queue is full!");
         }
     }
 
@@ -200,7 +200,7 @@ public final class MQConnection implements ShutdownListener {
                             messageData.getProps(), messageData.getBody());
                 }
             } catch (InterruptedException ie) {
-                LOGGER.info("sendMessages() poll() was interrupted: ", ie);
+                logger.info("sendMessages() poll() was interrupted: ", ie);
             }
         }
     }
@@ -222,11 +222,11 @@ public final class MQConnection implements ShutdownListener {
                     LazyRabbit.CF.setVirtualHost(virtualHost);
                 }
             } catch (KeyManagementException e) {
-                LOGGER.error("KeyManagementException: ", e);
+                logger.error("KeyManagementException: ", e);
             } catch (NoSuchAlgorithmException e) {
-                LOGGER.error("NoSuchAlgorithmException: ", e);
+                logger.error("NoSuchAlgorithmException: ", e);
             } catch (URISyntaxException e) {
-                LOGGER.error("URISyntaxException: ", e);
+                logger.error("URISyntaxException: ", e);
             }
             if (StringUtils.isNotEmpty(userName)) {
                 LazyRabbit.CF.setUsername(userName);
@@ -249,7 +249,7 @@ public final class MQConnection implements ShutdownListener {
                 connection = getConnectionFactory().newConnection();
                 connection.addShutdownListener(this);
             } catch (IOException e) {
-                LOGGER.warn("Connection refused", e);
+                logger.warn("Connection refused", e);
             } catch (TimeoutException e) {
                 e.printStackTrace();
             }
@@ -285,7 +285,7 @@ public final class MQConnection implements ShutdownListener {
      */
     private void send(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body) {
         if (exchange == null) {
-            LOGGER.error("Invalid configuration, exchange must not be null.");
+            logger.error("Invalid configuration, exchange must not be null.");
             return;
         }
 
@@ -301,7 +301,7 @@ public final class MQConnection implements ShutdownListener {
                     }
                 }
             } catch (IOException|ShutdownSignalException e) {
-                LOGGER.error("Cannot create channel", e);
+                logger.error("Cannot create channel", e);
                 channel = null; // reset
                 break;
             }
@@ -309,9 +309,9 @@ public final class MQConnection implements ShutdownListener {
                 try {
                     channel.basicPublish(exchange, routingKey, props, body);
                 } catch (IOException e) {
-                    LOGGER.error("Cannot publish message", e);
+                    logger.error("Cannot publish message", e);
                 } catch (AlreadyClosedException e) {
-                    LOGGER.error("Connection is already closed", e);
+                    logger.error("Connection is already closed", e);
                 }
 
                 break;
@@ -319,7 +319,7 @@ public final class MQConnection implements ShutdownListener {
                 try {
                     Thread.sleep(CONNECTION_WAIT);
                 } catch (InterruptedException ie) {
-                    LOGGER.error("Thread.sleep() was interrupted", ie);
+                    logger.error("Thread.sleep() was interrupted", ie);
                 }
             }
         }
@@ -329,7 +329,7 @@ public final class MQConnection implements ShutdownListener {
     public void shutdownCompleted(ShutdownSignalException cause) {
         if (cause.isHardError()) {
             if (!cause.isInitiatedByApplication()) {
-                LOGGER.warn("MQ connection was suddenly disconnected.");
+                logger.warn("MQ connection was suddenly disconnected.");
                 try {
                     if (connection != null && connection.isOpen()) {
                         connection.close();
@@ -338,7 +338,7 @@ public final class MQConnection implements ShutdownListener {
                         channel.close();
                     }
                 } catch (IOException|AlreadyClosedException e) {
-                    LOGGER.error("MQ Connection disconnected: ", e);
+                    logger.error("MQ Connection disconnected: ", e);
                 } catch (TimeoutException e) {
                     e.printStackTrace();
                 } finally {
@@ -347,7 +347,7 @@ public final class MQConnection implements ShutdownListener {
                 }
             }
         } else {
-            LOGGER.warn("MQ channel was suddenly disconnected.");
+            logger.warn("MQ channel was suddenly disconnected.");
         }
     }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
@@ -71,6 +71,10 @@ public class QueueListenerImpl extends QueueListener {
         EiffelActivityCanceledEvent event;
         if (li.isCancelled()) {
             String targetEvent = EiffelJobTable.getInstance().getEventTrigger(li.getId());
+            if (targetEvent == null) {
+                logger.debug("A cancelled queue item could not be mapped to an emitted ActT event: {}", li);
+                return;
+            }
             event = new EiffelActivityCanceledEvent(targetEvent);
             JSONObject json = event.getJson();
             publish(json);

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,65 +24,90 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * EiffelEvent EiffelActivityCanceledEvent representation
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityCanceledEvent.md">
+ * EiffelActivityCanceledEvent</a> (ActC) kind.
  *
- * Schema for this event can be found in the link below.
- * https://github.com/eiffel-community/eiffel/tree/master/schemas/EiffelActivityCanceledEvent
- *
- * @author Isac Holm &lt;isac.holm@axis.com&gt;
+ * See the Eiffel event documentation for more on the meaning of the attributes.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EiffelActivityCanceledEvent extends EiffelEvent {
-    /**
-     * Event Version implementation.
-     * @return Event Version
-     */
-    public String getVersion() {
-        return "1.1.0";
-    }
-    /**
-    * Constructor of EiffelActivityCanceledEvent.
-    * @param activityExecutionId
-    * event id of the EiffelActivityStartedEvent that was canceled.
-    */
-    public EiffelActivityCanceledEvent(String activityExecutionId) {
-        super();
-        super.setEventData(initEventData());
-        super.setEventLinks(initEventLinks(activityExecutionId));
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Data data;
+
+    public EiffelActivityCanceledEvent() {
+        super("EiffelActivityCanceledEvent", "1.1.0");
+        this.data = new EiffelActivityCanceledEvent.Data();
     }
 
-    /**
-     * set data key in the eiffel event.
-     * no data is required for this event but the objects need to be there.
-     * see eiffel schema in the link above.
-     * @return eventData map that was set.
-     */
-    private Map initEventData() {
-        Map<String, String> eventData = new HashMap<String, String>();
-        return eventData;
+    public EiffelActivityCanceledEvent(UUID activityID) {
+        this();
+        getLinks().add(new Link(Link.Type.ACTIVITY_EXECUTION, activityID));
     }
 
-    /**
-     * set the links of this event.
-     * @param activityExecutionId
-     * event id of the EiffelActivityStartedEvent that was canceled.
-     * @return eventLinks list that was set.
-     */
-    private List initEventLinks(String activityExecutionId) {
-        List<Map> eventLinks = new ArrayList<Map>();
-
-        Map<String, String> eventLink = new HashMap<String, String>();
-        eventLink.put("type", super.ACTIVITY_EXECUTION);
-        eventLink.put("target", activityExecutionId);
-
-        eventLinks.add(eventLink);
-
-        return eventLinks;
+    public Data getData() {
+        return data;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelActivityCanceledEvent that = (EiffelActivityCanceledEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        private String reason;
+
+        public String getReason() {
+            return reason;
+        }
+
+        public void setReason(String reason) {
+            this.reason = reason;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return Objects.equals(reason, data.reason);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(reason);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("reason", reason)
+                    .toString();
+        }
+    }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,66 +24,202 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * EiffelEvent EiffelActivityFinishedEvent representation.
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityStartedEvent.md">
+ * EiffelActivityStartedEvent</a> (ActF) kind.
  *
- * Schema for this event can be found in the link below.
- * https://github.com/eiffel-community/eiffel/tree/master/schemas/EiffelActivityFinished
- * @author Isac Holm &lt;isac.holm@axis.com&gt;
+ * See the Eiffel event documentation for more on the meaning of the attributes.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EiffelActivityFinishedEvent extends EiffelEvent {
-    /**
-     * Event Version implementation.
-     * @return Event Version
-     */
-    public String getVersion() {
-        return "1.1.0";
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Data data;
+
+    public EiffelActivityFinishedEvent(@JsonProperty("data") Data data) {
+        super("EiffelActivityFinishedEvent", "1.1.0");
+        this.data = data;
     }
 
-    /**
-     * constructor for EiffelActivityFinishedEvent.
-     * @param status status of jenkins-job translated into eiffel.
-     * @param activityExecutionId event id of the link target event.
-     */
-    public EiffelActivityFinishedEvent(String status, String activityExecutionId) {
-        super();
-        super.setEventData(initEventData(status));
-        super.setEventLinks(initEventLinks(activityExecutionId));
-
-    }
-    /**
-     * Initialize the eventData with job conclusion.
-     * @param status status of jenkins-job translated into eiffel.
-     * @return eventData data object for the event
-     */
-    private Map initEventData(String status) {
-        Map<String, Object> eventData = new HashMap<String, Object>();
-        Map<String, Object> outcome = new HashMap<String, Object>();
-
-        outcome.put("conclusion", status);
-        eventData.put("outcome", outcome);
-        return eventData;
-    }
-    /**
-     * Set the event link list containing link type(s) and event target(s).
-     * @param activityExecutionId event id of the event to link to.
-     * @return event link list for the event
-     */
-    private List initEventLinks(String activityExecutionId) {
-        List<Map> eventLinks = new ArrayList<Map>();
-
-        Map<String, String> eventLink = new HashMap<String, String>();
-        eventLink.put("type", super.ACTIVITY_EXECUTION);
-        eventLink.put("target", activityExecutionId);
-
-        eventLinks.add(eventLink);
-
-        return eventLinks;
+    public EiffelActivityFinishedEvent(Data.Outcome outcome, UUID activityID) {
+        this(new EiffelActivityFinishedEvent.Data(outcome));
+        getLinks().add(new EiffelEvent.Link(Link.Type.ACTIVITY_EXECUTION, activityID));
     }
 
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelActivityFinishedEvent that = (EiffelActivityFinishedEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private Outcome outcome;
+
+        private final List<PersistentLogs> persistentLogs = new ArrayList<>();
+
+        public Data(@JsonProperty("outcome") Outcome outcome) {
+            this.outcome = outcome;
+        }
+
+        public Outcome getOutcome() {
+            return outcome;
+        }
+
+        public void setOutcome(Outcome outcome) {
+            this.outcome = outcome;
+        }
+
+        public List<PersistentLogs> getPersistentLogs() {
+            return persistentLogs;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return Objects.equals(outcome, data.outcome) &&
+                    persistentLogs.equals(data.persistentLogs);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(outcome, persistentLogs);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("outcome", outcome)
+                    .append("persistentLogs", persistentLogs)
+                    .toString();
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class Outcome {
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private Conclusion conclusion;
+
+            private String description;
+
+            public Outcome(@JsonProperty("conclusion") Conclusion conclusion) {
+                this.conclusion = conclusion;
+            }
+
+            public Conclusion getConclusion() {
+                return conclusion;
+            }
+
+            public void setConclusion(Conclusion conclusion) {
+                this.conclusion = conclusion;
+            }
+
+            public String getDescription() {
+                return description;
+            }
+
+            public void setDescription(String description) {
+                this.description = description;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Outcome outcome = (Outcome) o;
+                return conclusion == outcome.conclusion &&
+                        Objects.equals(description, outcome.description);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(conclusion, description);
+            }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("conclusion", conclusion)
+                        .append("description", description)
+                        .toString();
+            }
+
+            public enum Conclusion {
+                SUCCESSFUL,
+                UNSUCCESSFUL,
+                FAILED,
+                ABORTED,
+                TIMED_OUT,
+                INCONCLUSIVE
+            }
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class PersistentLogs {
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private String name;
+
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private URI uri;
+
+            public PersistentLogs(@JsonProperty("name") String name, @JsonProperty("uri") URI uri) {
+                this.name = name;
+                this.uri = uri;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                PersistentLogs persistentLogs = (PersistentLogs) o;
+                return name.equals(persistentLogs.name) &&
+                        uri.equals(persistentLogs.uri);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(name, uri);
+            }
+        }
+    }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,60 +24,138 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * EiffelEvent EiffelActivityStartedEvent representation.
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityStartedEvent.md">
+ * EiffelActivityStartedEvent</a> (ActS) kind.
  *
- * Schema for this event can be found in the link below.
- * https://github.com/eiffel-community/eiffel/tree/master/schemas/EiffelActivityFinished
- * @author Isac Holm &lt;isac.holm@axis.com&gt;
+ * See the Eiffel event documentation for more on the meaning of the attributes.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EiffelActivityStartedEvent extends EiffelEvent {
-    /**
-     * Event Version implementation.
-     * @return Event Version
-     */
-    public String getVersion() {
-        return "1.1.0";
-    }
-    /**
-     * Constructor for EiffelActivityStartedEvent.
-     * @param activityExecutionId eiffel id of the link target event.
-     */
-    public EiffelActivityStartedEvent(String activityExecutionId) {
-        super();
-        super.setEventData(initEventData());
-        super.setEventLinks(initEventLinks(activityExecutionId));
-    }
-    /**
-     * Initiate eventData for this event.
-     * this returns an empty object for now beacuse eiffel expects it.
-     * It can be populated with not required information like executionUri and liveLogs.
-     * @return eventData object, currently empty.
-     */
-    private Map initEventData() {
-        Map<String, String> eventData = new HashMap<String, String>();
-        return eventData;
-    }
-    /**
-     * Initiate eventLinks for this event.
-     * @param activityExecutionId eiffel id of the link target event.
-     * @return eventLinks list of target eiffel events.
-     */
-    private List initEventLinks(String activityExecutionId) {
-        List<Map> eventLinks = new ArrayList<Map>();
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Data data;
 
-        Map<String, String> eventLink = new HashMap<String, String>();
-        eventLink.put("type", super.ACTIVITY_EXECUTION);
-        eventLink.put("target", activityExecutionId);
-
-        eventLinks.add(eventLink);
-
-        return eventLinks;
+    public EiffelActivityStartedEvent() {
+        super("EiffelActivityStartedEvent", "1.1.0");
+        this.data = new Data();
     }
 
+    public EiffelActivityStartedEvent(UUID activityID) {
+        this();
+        getLinks().add(new Link(Link.Type.ACTIVITY_EXECUTION, activityID));
+    }
+
+    public Data getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelActivityStartedEvent that = (EiffelActivityStartedEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        private URI executionUri;
+
+        private final List<LiveLogs> liveLogs = new ArrayList<>();
+
+        public URI getExecutionUri() {
+            return executionUri;
+        }
+
+        public void setExecutionUri(URI executionUri) {
+            this.executionUri = executionUri;
+        }
+
+        public List<LiveLogs> getLiveLogs() {
+            return liveLogs;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return Objects.equals(executionUri, data.executionUri) &&
+                    liveLogs.equals(data.liveLogs);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(executionUri, liveLogs);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("executionUri", executionUri)
+                    .append("liveLogs", liveLogs)
+                    .toString();
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class LiveLogs {
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private String name;
+
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private URI uri;
+
+            public LiveLogs(@JsonProperty("name") String name, @JsonProperty("uri") URI uri) {
+                this.name = name;
+                this.uri = uri;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                LiveLogs liveLogs = (LiveLogs) o;
+                return name.equals(liveLogs.name) &&
+                        uri.equals(liveLogs.uri);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(name, uri);
+            }
+        }
+    }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,55 +24,189 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * EiffelEvent EiffelActivityTriggeredEvent representation.
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityTriggeredEvent.md">
+ * EiffelActivityTriggeredEvent</a> (ActT) kind.
  *
- * Schema for this event can be found in the link below.
- * https://github.com/eiffel-community/eiffel/tree/master/schemas/EiffelActivityFinished
- * @author Isac Holm &lt;isac.holm@axis.com&gt;
+ * See the Eiffel event documentation for more on the meaning of the attributes.
  */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
 public class EiffelActivityTriggeredEvent extends EiffelEvent {
-    /**
-     * Event Version implementation.
-     * @return Event Version
-     */
-    public String getVersion() {
-        return "1.1.0";
-    }
-    /**
-     * Constructor for EiffelActivityTriggeredEvent.
-     * @param eventName full name of the triggered job.
-     */
-    public EiffelActivityTriggeredEvent(String eventName) {
-        super();
-        super.setEventData(initEventData(eventName));
-        super.setEventLinks(initEventLinks());
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Data data;
+
+    public EiffelActivityTriggeredEvent(@JsonProperty("data") Data data) {
+        super("EiffelActivityTriggeredEvent", "1.1.0");
+        this.data = data;
     }
 
-    /**
-     * Initialize the eventData.
-     * @param eventName full name of the triggered job.
-     * @return eventData object
-     */
-    private Map initEventData(String eventName) {
-        Map<String, String> eventData = new HashMap<String, String>();
-        eventData.put("name", eventName);
-
-        return eventData;
+    public EiffelActivityTriggeredEvent(String name) {
+        this(new EiffelActivityTriggeredEvent.Data(name));
     }
 
-    /**
-     * initialize the eventLinks.
-     * @return eventLinks, currently empty.
-     */
-    private List initEventLinks() {
-        List<Map> eventLinks = new ArrayList<Map>();
+    public Data getData() {
+        return data;
+    }
 
-        return eventLinks;
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelActivityTriggeredEvent that = (EiffelActivityTriggeredEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private String name;
+
+        private final List<String> categories = new ArrayList<>();
+
+        private final List<Trigger> triggers = new ArrayList<>();
+
+        private ExecutionType executionType;
+
+        public List<String> getCategories() {
+            return categories;
+        }
+
+        public Data(@JsonProperty("name") String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ExecutionType getExecutionType() {
+            return executionType;
+        }
+
+        public void setExecutionType(ExecutionType executionType) {
+            this.executionType = executionType;
+        }
+
+        public List<Trigger> getTriggers() {
+            return triggers;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return name.equals(data.name) &&
+                    categories.equals(data.categories) &&
+                    triggers.equals(data.triggers) &&
+                    executionType == data.executionType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, categories, triggers, executionType);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("name", name)
+                    .append("categories", categories)
+                    .append("triggers", triggers)
+                    .append("executionType", executionType)
+                    .toString();
+        }
+
+        public enum ExecutionType {
+            MANUAL,
+            SEMI_AUTOMATED,
+            AUTOMATED,
+            OTHER
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class Trigger {
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private Type type;
+
+            private String description;
+
+            public Trigger(@JsonProperty("type") Type type) {
+                this.type = type;
+            }
+
+            public Type getType() {
+                return type;
+            }
+
+            public void setType(Type type) {
+                this.type = type;
+            }
+
+            public String getDescription() {
+                return description;
+            }
+
+            public void setDescription(String description) {
+                this.description = description;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Trigger trigger = (Trigger) o;
+                return type == trigger.type &&
+                        Objects.equals(description, trigger.description);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(type, description);
+            }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("type", type)
+                        .append("description", description)
+                        .toString();
+            }
+
+            public enum Type {
+                MANUAL,
+                EIFFEL_EVENT,
+                SOURCE_CHANGE,
+                TIMER,
+                OTHER
+            }
+        }
     }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018 Axis Communications AB.
+ Copyright 2021 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,95 +24,309 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Util;
-
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.time.Instant;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import net.sf.json.JSONObject;
 /**
- * EiffelEvent base containing object requiered in all events.
+ * A base class for Eiffel events that defines the common event attributes (<tt>meta</tt> and <tt>links</tt>)
+ * and makes it easy for subclasses to add an event-specific <tt>data</tt> attribute.
  *
- * Schema for all events can be found in the link below.
- * https://github.com/eiffel-community/eiffel/tree/master/schemas
- *
- * Protocol specification for all events can be found in the link below
- * https://github.com/eiffel-community/eiffel/tree/master/eiffel-vocabulary
- * @author Isac Holm &lt;isac.holm@axis.com&gt;
+ * See the Eiffel event documentation for each concrete event type for more on the meaning of the attributes.
  */
-abstract class EiffelEvent {
-    public final static String META_SOURCE_NAME = "JENKINS_EIFFEL_BROADCASTER";
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "meta.type")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = EiffelActivityCanceledEvent.class, name = "EiffelActivityCanceledEvent"),
+        @JsonSubTypes.Type(value = EiffelActivityFinishedEvent.class, name = "EiffelActivityFinishedEvent"),
+        @JsonSubTypes.Type(value = EiffelActivityStartedEvent.class, name = "EiffelActivityStartedEvent"),
+        @JsonSubTypes.Type(value = EiffelActivityTriggeredEvent.class, name = "EiffelActivityTriggeredEvent"),
+})
+public class EiffelEvent {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final List<Link> links = new ArrayList<>();
 
-    /**
-    * EiffelEvent Constants.
-    */
-    public static final String ACTIVITY_EXECUTION = "ACTIVITY_EXECUTION";
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final Meta meta;
 
-    /**
-    * getter for eventMeta.
-    * @return event metadata
-    */
-    public Map<String, Object> getEventMeta() {
-        return eventMeta;
+    public EiffelEvent(String type, String version) {
+        this.meta = new Meta(type, version);
     }
 
-    /**
-    * getter for eventLinks.
-    * @return event metadata
-    */
-    public List<List> getEventLinks() {
-        return eventLinks;
-    }
-    /**
-    * getter for eventLinks.
-    * @return event metadata
-    */
-    public Map<String, Map> getEventData() {
-        return eventData;
+    public List<Link> getLinks() {
+        return links;
     }
 
-    private Map<String, Object> eventMeta = new HashMap<String, Object>();
-    private List<List> eventLinks = new ArrayList<List>();
-    private Map<String, Map> eventData = new HashMap<String, Map>();
-
-    public abstract String getVersion();
-
-    public void setEventLinks(List links) {
-        this.eventLinks = links;
+    public Meta getMeta() {
+        return meta;
     }
 
-    public void setEventData(Map data) {
-        this.eventData = data;
+    public String toJSON() throws JsonProcessingException {
+        return new ObjectMapper().writeValueAsString(this);
     }
-    /**
-    * Constructor for EiffelEvent.
-    */
-    public EiffelEvent() {
-        HashMap<String, String> metaSourceMap = new HashMap<>();
-        metaSourceMap.put("name", META_SOURCE_NAME);
 
-        eventMeta.put("id", Util.getUUID());
-        eventMeta.put("time", Util.getTime());
-        eventMeta.put("type", this.getClass().getSimpleName());
-        eventMeta.put("version", getVersion());
-        eventMeta.put("source", metaSourceMap);
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        EiffelEvent that = (EiffelEvent) o;
+        return links.equals(that.links) &&
+                meta.equals(that.meta);
     }
-    /**
-    * Get this event as Json.
-    * @return eiffel event in json format.
-    */
-    public JSONObject getJson() {
-        JSONObject json = new JSONObject();
-        json.put("meta", eventMeta);
-        if (eventData != null) {
-            json.put("data", eventData);
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(links, meta);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", links)
+                .append("meta", meta)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Link {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private UUID target;
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private Type type;
+
+        public Link(@JsonProperty("type") Type type, @JsonProperty("target") UUID target) {
+            this.target = target;
+            this.type = type;
         }
-        if (eventLinks != null) {
-            json.put("links", eventLinks);
+
+        public UUID getTarget() {
+            return target;
         }
-        return json;
+
+        public void setTarget(UUID target) {
+            this.target = target;
+        }
+
+        public Type getType() {
+            return type;
+        }
+
+        public void setType(Type type) {
+            this.type = type;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Link link = (Link) o;
+            return target.equals(link.target) &&
+                    type.equals(link.type);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(target, type);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("target", target)
+                    .append("type", type)
+                    .toString();
+        }
+
+        public enum Type {
+            ACTIVITY_EXECUTION,
+            CAUSE,
+            CONTEXT,
+            FLOW_CONTEXT,
+            PREVIOUS_ACTIVITY_EXECUTION
+        }
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Meta {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private final UUID id = UUID.randomUUID();
+
+        private Source source = new Source();
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private final long time = Instant.now().toEpochMilli();
+
+        private final List<String> tags = new ArrayList<>();
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private String type;
+
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private final String version;
+
+        public Meta(@JsonProperty("type") String type, @JsonProperty("version") String version) {
+            this.type = type;
+            this.version = version;
+        }
+
+        public UUID getId() {
+            return id;
+        }
+
+        public Source getSource() {
+            return source;
+        }
+
+        public void setSource(Source source) {
+            this.source = source;
+        }
+
+        public long getTime() {
+            return time;
+        }
+
+        public List<String> getTags() {
+            return tags;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Meta meta = (Meta) o;
+            return time == meta.time &&
+                    id.equals(meta.id) &&
+                    Objects.equals(source, meta.source) &&
+                    tags.equals(meta.tags) &&
+                    type.equals(meta.type) &&
+                    version.equals(meta.version);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(id, source, time, tags, type, version);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("id", id)
+                    .append("source", source)
+                    .append("time", time)
+                    .append("tags", tags)
+                    .append("type", type)
+                    .append("version", version)
+                    .toString();
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class Source {
+            public final static String DEFAULT_NAME = "JENKINS_EIFFEL_BROADCASTER";
+
+            private String domainId;
+
+            private String host;
+
+            private String name;
+
+            private String serializer;
+
+            private URI uri;
+
+            public Source() {
+                this.name = DEFAULT_NAME;
+            }
+
+            public String getDomainId() {
+                return domainId;
+            }
+
+            public void setDomainId(String domainId) {
+                this.domainId = domainId;
+            }
+
+            public String getHost() {
+                return host;
+            }
+
+            public void setHost(String host) {
+                this.host = host;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public String getSerializer() {
+                return serializer;
+            }
+
+            public void setSerializer(String serializer) {
+                this.serializer = serializer;
+            }
+
+            public URI getUri() {
+                return uri;
+            }
+
+            public void setUri(URI uri) {
+                this.uri = uri;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Source source = (Source) o;
+                return Objects.equals(domainId, source.domainId) &&
+                        Objects.equals(host, source.host) &&
+                        Objects.equals(name, source.name) &&
+                        Objects.equals(serializer, source.serializer) &&
+                        Objects.equals(uri, source.uri);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(domainId, host, name, serializer, uri);
+            }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("domainId", domainId)
+                        .append("host", host)
+                        .append("name", name)
+                        .append("serializer", serializer)
+                        .append("uri", uri)
+                        .toString();
+            }
+        }
     }
 }
-

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -87,6 +87,6 @@ public class EmittedEventsTest {
         job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
         jenkins.buildAndAssertSuccess(job);
 
-        assertThat(Mocks.messages.size(), is(4));
+        assertThat(Mocks.messages.size(), is(3));
     }
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -1,0 +1,92 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.matrix.Axis;
+import hudson.matrix.AxisList;
+import hudson.matrix.MatrixProject;
+import hudson.model.FreeStyleProject;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * Tests of the correctness of the events emitted from all listeners.
+ * For now we only check that we get the correct number of events,
+ * i.e. the contents of the actual events is never inspected.
+ */
+public class EmittedEventsTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        new Mocks.RabbitMQConnectionMock();
+    }
+
+    @Before
+    public void setUp() {
+        Mocks.messages.clear();
+        EiffelBroadcasterConfig.getInstance().setEnableBroadcaster(true);
+    }
+
+    @Test
+    public void testExpectedMessageCountForFreestyleBuild() throws Exception {
+        FreeStyleProject job = jenkins.createFolder("testfolder")
+                .createProject(FreeStyleProject.class, "test");
+        jenkins.buildAndAssertSuccess(job);
+
+        assertThat(Mocks.messages.size(), is(3));
+    }
+
+    @Test
+    public void testExpectedMessageCountForMatrixBuild() throws Exception {
+        MatrixProject job = jenkins.createFolder("testfolder")
+                .createProject(MatrixProject.class, "test");
+        job.setAxes(new AxisList(new Axis("axislabel", "value1", "value2")));
+        jenkins.buildAndAssertSuccess(job);
+
+        // ActT/ActS/ActF for the top-level build and builds for a two-by-one matrix results in
+        // 3 * (1 + 2 * 1) = 9 events.
+        assertThat(Mocks.messages.size(), is(9));
+    }
+
+    @Test
+    public void testExpectedMessageCountForPipelineBuild() throws Exception {
+        WorkflowJob job = jenkins.createFolder("testfolder")
+                .createProject(WorkflowJob.class, "test");
+        job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
+        jenkins.buildAndAssertSuccess(job);
+
+        assertThat(Mocks.messages.size(), is(4));
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -24,10 +24,16 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityCanceledEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityFinishedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityStartedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import hudson.matrix.Axis;
 import hudson.matrix.AxisList;
 import hudson.matrix.MatrixProject;
 import hudson.model.FreeStyleProject;
+import hudson.model.Result;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
@@ -36,6 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import static com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
@@ -60,33 +67,170 @@ public class EmittedEventsTest {
     }
 
     @Test
-    public void testExpectedMessageCountForFreestyleBuild() throws Exception {
+    public void testEventsForSuccessfulFreestyleBuild() throws Exception {
         FreeStyleProject job = jenkins.createFolder("testfolder")
                 .createProject(FreeStyleProject.class, "test");
         jenkins.buildAndAssertSuccess(job);
 
-        assertThat(Mocks.messages.size(), is(3));
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        assertThat(actT.getData(), is(actTData));
+
+        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        EiffelActivityStartedEvent.Data actSData = new EiffelActivityStartedEvent.Data();
+        assertThat(actS.getData(), is(actSData));
+        assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        EiffelActivityFinishedEvent.Data actFData = new EiffelActivityFinishedEvent.Data(
+                new EiffelActivityFinishedEvent.Data.Outcome(
+                        EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
+        assertThat(actF.getData(), is(actFData));
+        assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        assertThat(events.isEmpty(), is(true));
     }
 
     @Test
-    public void testExpectedMessageCountForMatrixBuild() throws Exception {
+    public void testEventsForCanceledFreestyleBuild() throws Exception {
+        // Attempt to allocate a node with a label expression that won't ever be satisfied,
+        // forcing it to end up in the queue so that we have time to cancel it.
+        FreeStyleProject job = jenkins.createFolder("testfolder")
+                .createProject(FreeStyleProject.class, "test");
+        job.setAssignedLabel(jenkins.jenkins.getLabel("no-such-node"));
+
+        // Unfortunately the QueueTaskFuture returned by schedulebuild2() only allows us to
+        // wait for the start or completion of the build (neither of which will ever happen),
+        // so to access the queued-up build and cancel it we have to locate it in the queue.
+        // But our goal is just to cancel it so we might as well clear the whole queue.
+        job.scheduleBuild2(0);
+        jenkins.jenkins.getQueue().clear();
+
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        assertThat(actT.getData(), is(actTData));
+
+        EiffelActivityCanceledEvent actC = events.findNext(EiffelActivityCanceledEvent.class);
+        assertThat(actC, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        assertThat(events.isEmpty(), is(true));
+    }
+
+    @Test
+    public void testEventsForSuccessfulForMatrixBuild() throws Exception {
         MatrixProject job = jenkins.createFolder("testfolder")
                 .createProject(MatrixProject.class, "test");
-        job.setAxes(new AxisList(new Axis("axislabel", "value1", "value2")));
+        // Using more than one value on the axis would theoretically cover more cases,
+        // but we'd have to spend more effort evaluating the resulting events.
+        String axisValue = "value1";
+        job.setAxes(new AxisList(new Axis("axislabel", axisValue)));
         jenkins.buildAndAssertSuccess(job);
 
-        // ActT/ActS/ActF for the top-level build and builds for a two-by-one matrix results in
-        // 3 * (1 + 2 * 1) = 9 events.
-        assertThat(Mocks.messages.size(), is(9));
+        EventSet events = new EventSet(Mocks.messages);
+
+        // First check the ActT/ActS/ActF sequence of the top-level build.
+        EiffelActivityTriggeredEvent toplevelActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        assertThat(toplevelActT.getData(), is(actTData));
+
+        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class,
+                linksTo(toplevelActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+        EiffelActivityStartedEvent.Data actSData = new EiffelActivityStartedEvent.Data();
+        assertThat(actS.getData(), is(actSData));
+
+        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class,
+                linksTo(toplevelActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+        EiffelActivityFinishedEvent.Data actFData = new EiffelActivityFinishedEvent.Data(
+                new EiffelActivityFinishedEvent.Data.Outcome(
+                        EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
+        assertThat(actF.getData(), is(actFData));
+
+        // Check that we get a child activity. Eventually it should have a CAUSE link
+        // pointing to the top-level activity.
+        EiffelActivityTriggeredEvent childActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        // To avoid tight coupling to the exact build name let's just perform a sanity check
+        // to make sure it contains the job name and the matrix axis name.
+        assertThat(childActT.getData().getName(), containsString("test"));
+        assertThat(childActT.getData().getName(), containsString(axisValue));
+
+        EiffelActivityStartedEvent childActS = events.findNext(EiffelActivityStartedEvent.class,
+                linksTo(childActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+        EiffelActivityStartedEvent.Data childActSData = new EiffelActivityStartedEvent.Data();
+        assertThat(childActS.getData(), is(childActSData));
+
+        EiffelActivityFinishedEvent childActF = events.findNext(EiffelActivityFinishedEvent.class,
+                linksTo(childActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+        EiffelActivityFinishedEvent.Data childActFData = new EiffelActivityFinishedEvent.Data(
+                new EiffelActivityFinishedEvent.Data.Outcome(
+                        EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
+        assertThat(childActF.getData(), is(childActFData));
+
+        assertThat(events.isEmpty(), is(true));
     }
 
     @Test
-    public void testExpectedMessageCountForPipelineBuild() throws Exception {
+    public void testEventsForSuccessfulPipelineBuild() throws Exception {
         WorkflowJob job = jenkins.createFolder("testfolder")
                 .createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
         jenkins.buildAndAssertSuccess(job);
 
-        assertThat(Mocks.messages.size(), is(3));
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        assertThat(actT.getData(), is(actTData));
+
+        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        EiffelActivityStartedEvent.Data actSData = new EiffelActivityStartedEvent.Data();
+        assertThat(actS.getData(), is(actSData));
+        assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        EiffelActivityFinishedEvent.Data actFData = new EiffelActivityFinishedEvent.Data(
+                new EiffelActivityFinishedEvent.Data.Outcome(
+                        EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
+        assertThat(actF.getData(), is(actFData));
+        assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        assertThat(events.isEmpty(), is(true));
     }
+
+    @Test
+    public void testEventsForFailingPipelineBuild() throws Exception {
+        WorkflowJob job = jenkins.createFolder("testfolder")
+                .createProject(WorkflowJob.class, "test");
+        job.setDefinition(new CpsFlowDefinition("node { error 'something went bad' }", true));
+        jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
+
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        assertThat(actT.getData(), is(actTData));
+
+        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        EiffelActivityStartedEvent.Data actSData = new EiffelActivityStartedEvent.Data();
+        assertThat(actS.getData(), is(actSData));
+        assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        EiffelActivityFinishedEvent.Data actFData = new EiffelActivityFinishedEvent.Data(
+                new EiffelActivityFinishedEvent.Data.Outcome(
+                        EiffelActivityFinishedEvent.Data.Outcome.Conclusion.FAILED));
+        assertThat(actF.getData(), is(actFData));
+        assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+
+        assertThat(events.isEmpty(), is(true));
+    }
+
+    // Here we should have a test that verifies that an ActC event with a correct link
+    // to the ActT event of a pipeline build is emitted, but because of the bug and race condition
+    // described in https://github.com/jenkinsci/eiffel-broadcaster-plugin/issues/18 it's not
+    // realistic to write such a test right now (not even one that expects a failure since there's
+    // more than one possible failure).
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
@@ -1,0 +1,103 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.List;
+import org.hamcrest.Matcher;
+
+/**
+ * Maintains an ordered set of events received from the plugin by the mocked {@link MQConnection}.
+ * The raw messages are deserialized to {@link EiffelEvent} objects and there are methods
+ * to locate an event matching a criterion and pop it from the event set of events. This makes
+ * it possible to write tests that aren't tightly coupled to the exact order of events.
+ */
+public class EventSet {
+    private List<EiffelEvent> events = new ArrayList<>();
+
+    /**
+     * Initializes a new class instance by deserializing each JSON string in the provided list
+     * and collecting the resulting {@link EiffelEvent} objects.
+     *
+     * @param messages a list of Eiffel events, serialized as JSON strings
+     * @throws JsonProcessingException if the JSON deserialization fails, e.g. because
+     * the JSON string is malformed or if the mapping of the JSON object to a Java object fails
+     */
+    public EventSet(List<String> messages) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        for (String message : messages) {
+            events.add(mapper.readValue(message, EiffelEvent.class));
+        }
+    }
+
+    /**
+     * Finds the first event of a particular class, pops it from the event set, and returns it.
+     *
+     * @param clazz the class to look for
+     * @return the first matching event
+     * @throws java.util.NoSuchElementException if no event of the specified class could be found
+     */
+    public <T> T findNext(Class<T> clazz) {
+        T event = events.stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .findFirst()
+                .get();
+        events.remove(event);
+        return event;
+    }
+
+    /**
+     * Finds the first event of a particular class that matches a condition, pops it from
+     * the event set, and returns it.
+     *
+     * @param clazz the class to look for
+     * @param matcher a {@link Matcher} that will be evaluated against the list of
+     * @return the first matching event
+     * @throws java.util.NoSuchElementException if no event matching the condition could be found
+     */
+    public <T> T findNext(Class<T> clazz, Matcher<EiffelEvent> matcher) {
+        T event = events.stream()
+                .filter(clazz::isInstance)
+                .filter(matcher::matches)
+                .map(clazz::cast)
+                .findFirst()
+                .get();
+        events.remove(event);
+        return event;
+    }
+
+    /**
+     * Returns whether there are any remaining events in the set.
+     *
+     * @return true if the event set is empty, otherwise false
+     */
+    public boolean isEmpty() {
+        return events.isEmpty();
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
@@ -1,0 +1,58 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * A Hamcrest {@link Matcher} that checks whether an Eiffel event has
+ * a link of a particular type to another Eiffel event.
+ */
+public class Matchers {
+    /**
+     * Returns a matcher that checks whether the subject {@link EiffelEvent} contains
+     * a link of the specified type to another specified EiffelEvent.
+     *
+     * @param target the target event that the link is expected to point to
+     * @param type the link type
+     */
+    public static Matcher<EiffelEvent> linksTo(EiffelEvent target, EiffelEvent.Link.Type type) {
+        EiffelEvent.Link expectedLink = new EiffelEvent.Link(type, target.getMeta().getId());
+        return new TypeSafeMatcher<EiffelEvent>() {
+            @Override
+            protected boolean matchesSafely(EiffelEvent eiffelEvent) {
+                return eiffelEvent.getLinks().contains(expectedLink);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("event containing link: ").appendValue(expectedLink);
+            }
+        };
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Mocks.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Mocks.java
@@ -1,0 +1,56 @@
+/*
+ The MIT License
+
+ Copyright 2015 Sony Mobile Communications Inc. All rights reserved.
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.rabbitmq.client.AMQP;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import mockit.Mock;
+import mockit.MockUp;
+
+/**
+ * Test mocks.
+ *
+ * @author Örjan Percy &lt;orjan.percy@sonymobile.com&gt;
+ * @author Magnus Bäck &lt;magnus.back@axis.com&gt;
+ */
+final class Mocks {
+    /** Stores received messages. */
+    public static final List<String> messages = new CopyOnWriteArrayList<>();
+
+    // Private constructor to avoid unnecessary instantiation of the class
+    private Mocks() { }
+
+    /**
+     * Mocks the {@link MQConnection} singleton and captures all received messages in {@link #messages}.
+     * */
+    public static final class RabbitMQConnectionMock extends MockUp<MQConnection> {
+        @Mock
+        public void addMessageToQueue(String exchangeName, String routingKey, AMQP.BasicProperties props, byte[] body) {
+            messages.add(new String(body));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds tests to check the contents of the emitted events for a couple of common job types (freestyle, matrix, pipeline). To make writing the tests less painful the event classes are refactored to actually model the Eiffel events instead of storing the event data in hashmaps. This should also simplify future expansions of the event contents (causes etc) and make it less error-prone. Fixes #13.

I'm sorry for this huge PR, but I've at least tried to split all logical changes into different commits. I recommend that you look at the individual commits rather than the diff of the whole PR.