### PR TITLE
Add trigger information to the ActT events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>pipeline-build-step</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
             <scope>test</scope>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityTriggerAction.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityTriggerAction.java
@@ -1,0 +1,77 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.model.Action;
+import javax.annotation.CheckForNull;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * An {@link Action} for storing the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityTriggeredEvent.md">
+ * EiffelActivityTriggeredEvent</a> that was emitted when a build was enqueued.
+ */
+@ExportedBean
+public class EiffelActivityTriggerAction implements Action {
+    private String eventJSON;
+
+    public EiffelActivityTriggerAction(EiffelActivityTriggeredEvent event) throws JsonProcessingException {
+        this.eventJSON = event.toJSON();
+    }
+
+    /** Returns the build's EiffelActivityTriggeredEvent. */
+    public EiffelActivityTriggeredEvent getEvent() throws JsonProcessingException {
+        // It might make sense to cache this value for future use. It's a memory/CPU trade-off.
+        return new ObjectMapper().readValue(eventJSON, EiffelActivityTriggeredEvent.class);
+    }
+
+    /** Returns the build's EiffelActivityTriggeredEvent expressed as a JSON string. */
+    @Exported
+    public String getEventJSON() {
+        return eventJSON;
+    }
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
@@ -24,14 +24,14 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
- * A Hamcrest {@link Matcher} that checks whether an Eiffel event has
- * a link of a particular type to another Eiffel event.
+ * A collection of Hamcrest {@link Matcher} functions that inspect the state of Eiffel events.
  */
 public class Matchers {
     /**
@@ -52,6 +52,48 @@ public class Matchers {
             @Override
             public void describeTo(Description description) {
                 description.appendText("event containing link: ").appendValue(expectedLink);
+            }
+        };
+    }
+
+    /**
+     * Returns a matcher that checks whether the subject {@link EiffelActivityTriggeredEvent}
+     * has a trigger with the specified type.
+     *
+     * @param type the desired type of the trigger
+     */
+    public static Matcher<EiffelActivityTriggeredEvent> hasTrigger(
+            EiffelActivityTriggeredEvent.Data.Trigger.Type type) {
+        return hasTrigger(type, "");
+    }
+
+    /**
+     * Returns a matcher that checks whether the subject {@link EiffelActivityTriggeredEvent}
+     * has a trigger with the specified type.
+     *
+     * @param type the type that the trigger is expected to have
+     * @param descriptionSubstring a string that should appear in the trigger's description
+     */
+    public static Matcher<EiffelActivityTriggeredEvent> hasTrigger(
+            EiffelActivityTriggeredEvent.Data.Trigger.Type type, String descriptionSubstring) {
+        return new TypeSafeMatcher<EiffelActivityTriggeredEvent>() {
+            @Override
+            protected boolean matchesSafely(EiffelActivityTriggeredEvent eiffelEvent) {
+                return eiffelEvent.getData().getTriggers().stream()
+                        .anyMatch(t -> t.getDescription() != null
+                                && t.getDescription().contains(descriptionSubstring)
+                                && t.getType() == type);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                if (descriptionSubstring.isEmpty()) {
+                    description.appendText(String.format("event containing a %s trigger", type));
+                } else {
+                    description.appendText(String.format(
+                            "event containing a %s trigger and the substring \"%s\" in the description",
+                            type, descriptionSubstring));
+                }
             }
         };
     }


### PR DESCRIPTION
When a build is enqueued, populate the ActT event's data.trigger attribute with objects translated from the build's causes. We currently support TimerTriggerCause, SCMTriggerCause, and UpstreamCause. The first two ones are quite straightforward and only involves setting the trigger type (to TIMER and SOURCE_CHANGE, respectively) but the UpstreamCause requires some work.

Jenkins can tell us which build triggered the current build, but what we're interested in is the ID of that build's ActT event since that's what should end up in the CAUSE link. We introduce a new action for this, EiffelActivityTriggerAction, which also makes the ActT event available to the outside world (via e.g. the $BUILD_URL/api/json endpoint). We'll also have use for it when we implement issue #20.

Fixes #11.