### PR TITLE
Fix broken JSON deserialization

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
@@ -25,6 +25,8 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -37,6 +39,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * See the Eiffel event documentation for more on the meaning of the attributes.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityCanceledEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Data data;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
@@ -26,6 +26,8 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * See the Eiffel event documentation for more on the meaning of the attributes.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityFinishedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Data data;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
@@ -26,6 +26,8 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * See the Eiffel event documentation for more on the meaning of the attributes.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityStartedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Data data;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
@@ -26,6 +26,8 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -39,6 +41,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
  * See the Eiffel event documentation for more on the meaning of the attributes.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityTriggeredEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
     private final Data data;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/InvalidJsonPayloadException.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/InvalidJsonPayloadException.java
@@ -1,0 +1,41 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * Thrown when the JSON representation of an Eiffel event lacks an <tt>meta.type</tt> member that
+ * determines the event type.
+ */
+public class InvalidJsonPayloadException extends JsonProcessingException {
+    public InvalidJsonPayloadException(String msg) {
+        super(msg);
+    }
+
+    public InvalidJsonPayloadException(String msg, Throwable rootCause) {
+        super(msg, rootCause);
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/UnsupportedEventTypeException.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/UnsupportedEventTypeException.java
@@ -1,0 +1,42 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * Thrown when an attempt is made to deserialize the JSON representation of an Eiffel event
+ * of an unsupported type, i.e. an event type that doesn't have a corresponding
+ * {@link EiffelEvent} subclass.
+ */
+public class UnsupportedEventTypeException extends JsonProcessingException {
+    protected UnsupportedEventTypeException(String msg) {
+        super(msg);
+    }
+
+    protected UnsupportedEventTypeException(String msg, Throwable rootCause) {
+        super(msg, rootCause);
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
@@ -1,0 +1,56 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EiffelEventTest {
+    @Test
+    public void testJsonDeserialization_ChoosesCorrectSubclass() throws JsonProcessingException {
+        // We instantiate an arbitrary concrete EiffelEvent subclass and make sure that when we
+        // deserialize the string back into an EiffelEvent we get an instance of the same class.
+        EiffelActivityTriggeredEvent originalEvent = new EiffelActivityTriggeredEvent("activity name");
+        EiffelEvent deserializedEvent = new ObjectMapper().readValue(originalEvent.toJSON(), EiffelEvent.class);
+        assertThat(deserializedEvent, instanceOf(originalEvent.getClass()));
+    }
+
+    @Test(expected = UnsupportedEventTypeException.class)
+    public void testJsonDeserialization_WithUnsupportedEventType() throws IOException {
+        new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
+    }
+
+    @Test(expected = InvalidJsonPayloadException.class)
+    public void testJsonDeserialization_WithMissingTypeInfo() throws IOException {
+        new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelCompositionDefinedEvent_without_meta.json"), EiffelEvent.class);
+    }
+}

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelCompositionDefinedEvent.json
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelCompositionDefinedEvent.json
@@ -1,0 +1,34 @@
+{
+  "meta": {
+    "type": "EiffelCompositionDefinedEvent",
+    "version": "3.0.0",
+    "time": 1234567890,
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+  },
+  "data": {
+    "name": "myCompositionName",
+    "version": "42.0.7"
+  },
+  "links": [
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
+    },
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
+    }
+  ]
+}

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelCompositionDefinedEvent_without_meta.json
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelCompositionDefinedEvent_without_meta.json
@@ -1,0 +1,28 @@
+{
+  "data": {
+    "name": "myCompositionName",
+    "version": "42.0.7"
+  },
+  "links": [
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee2"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee3"
+    },
+    {
+      "type": "ELEMENT",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee4"
+    },
+    {
+      "type": "PREVIOUS_VERSION",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee5"
+    }
+  ]
+}


### PR DESCRIPTION
Previously we (thought we) used some clever Jackson tricks to deserialize an arbitrary Eiffel event JSON string into a instance of the correct class based on the event type declared in the meta section of the event by using the following EiffelEvent class annotations:

```Java
    @JsonTypeInfo(use = JsonTypeInfo.Id.NAME,
                  include = JsonTypeInfo.As.PROPERTY,
                  property = "meta.type")
    @JsonSubTypes({
            @JsonSubTypes.Type(value = EiffelActivityCanceledEvent.class,
                               name = "EiffelActivityCanceledEvent"),
            ...
    })
```

This appeared to work, but:

- Jackson doesn't actually support nested field references (not with      this notation anyway). See e.g. https://stackoverflow.com/a/48467746.
- When serializing objects we got an unwanted "meta.type" key in the      resulting JSON payload. This could possibly be worked around with      the `@JsonIgnoreProperties` notation.
- Changing the `@JsonTypeInfo` property name to a bogus string that      absolutely doesn't match the name of an existing field still works.

Let's avoid black magic and use a custom deserializer to pick the right concrete EiffelEvent subclass for us.