### PR TITLE
Add EiffelCause and $JOB_URL/eiffel/build API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,30 @@ Read more about the Eiffel protocol on https://github.com/eiffel-community/eiffe
 ### Notes
 - Current versions of each event can be found in the getVersion() function in the [sourcecode.](https://github.com/Isacholm/EiffelBroadcaster/tree/master/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel)
 
+## API
+The plugin will do its best to populate the emitted
+EiffelActivityTriggeredEvent with information taken from the causes of
+the build, but in many cases you'll want to inject additional Eiffel links
+that the plugin can't figure out on its own. This can be done with the
+$JOB_URL/eiffel/build API endpoint which works nearly identially to the
+standard $JOB_URL/build endpoint except that it requires an additional
+`eiffellinks` form parameter that contains the Eiffel links to include in
+the EiffelActivityTriggeredEvent. `eiffellinks` follows the same schema
+as the `links` value in Eiffel events. Example (payload lacking URL
+encoding to improve readability):
+```
+POST $JOB_URL/eiffel/build
+Content-Type: application/x-www-form-urlencoded
+
+json={"eiffellinks": [{"target": "662b3813-bef4-4588-bf75-ffaead24a6d5", "type": "CAUSE"}], "parameter": [{"name": "PARAM_NAME", "value": "param value"}]}
+```
+The `eiffellinks` key is mandatory for this endpoint but `parameter` is
+optional. If the latter is omitted and the job is parameterized the default
+values for all parameters will be used.
+
+If at least one CAUSE link is included in `eiffellinks`, an `EIFFEL_EVENT`
+trigger will be included in the EiffelActivityTriggeredEvent.
+
 ## How to build and install this plugin from source
 In the EiffelBroadcaster root folder, use maven to compile.
 ```
@@ -53,7 +77,7 @@ This plugin is part of the [Eiffel Community](https://github.com/eiffel-communit
 ```
 The MIT License
 
-Copyright 2018 Axis Communications AB.
+Copyright 2018-2021 Axis Communications AB.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksAction.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksAction.java
@@ -1,0 +1,277 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+ Copyright 2014 Jesse Glick.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.CollectionType;
+import hudson.model.Action;
+import hudson.model.Cause;
+import hudson.model.CauseAction;
+import hudson.model.Item;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.Queue;
+import hudson.model.Run;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
+import javax.servlet.ServletException;
+import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
+import jenkins.util.TimeDuration;
+import net.sf.json.JSONArray;
+import net.sf.json.JSONException;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.RequirePOST;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
+import static javax.servlet.http.HttpServletResponse.SC_CREATED;
+
+/**
+ * An {@link Action} that attaches an additional API endpoint to jobs for starting a build with one
+ * or more Eiffel links. The endpoint is $JOB_URL/eiffel/build and should behave as the regular
+ * $JOB_URL/build endpoint, i.e. you can supply parameters by posting a form with a JSON string.
+ * Additionally, it requires a (possibly empty) list of Eiffel links. Example (payload lacking URL
+ * encoding to improve readability):
+ * <pre>
+ * POST $JOB_URL/eiffel/build
+ * Content-Type: application/x-www-form-urlencoded
+ *
+ * json={"eiffellinks": [{"target": "662b3813-bef4-4588-bf75-ffaead24a6d5", "type": "CAUSE"}], "parameter": [{"name": "PARAM_NAME", "value": "param value"}]}
+ * </pre>
+ * The Eiffel links, if any, will be passed to the build as an {@link EiffelCause} cause.
+ * That cause will be used when piecing together the
+ * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}
+ * which gets captured in the {@link Run}'s {@link EiffelActivityAction}.
+ */
+public class BuildWithEiffelLinksAction<
+        JobT extends Job<JobT, RunT> & ParameterizedJobMixIn.ParameterizedJob<JobT, RunT>,
+        RunT extends Run<JobT, RunT> & Queue.Executable>
+        implements Action {
+    /** The form parameter that holds the Eiffel links. */
+    public static final String FORM_PARAM_EIFFELLINKS = "eiffellinks";
+
+    /** The form parameter that holds the build parameters. */
+    public static final String FORM_PARAM_PARAMETERS = "parameter";
+
+    /**
+     * The immediate suffix to the URL of the {@link Job}, i.e. the URLs served by this action will have
+     * the form $JOB_URL/$URL_SUFFIX.
+     */
+    public static final String URL_SUFFIX = "eiffel";
+
+    private final JobT job;
+
+    public BuildWithEiffelLinksAction(JobT job) {
+        this.job = job;
+    }
+
+    /**
+     * Responds to a /build request by parsing the posted form and transforming the Eiffel links
+     * and (optionally) build parameters into actions that'll get passed to the new build.
+     */
+    @RequirePOST
+    public void doBuild(StaplerRequest req, StaplerResponse rsp, @QueryParameter TimeDuration delay)
+            throws IOException {
+        job.checkPermission(Item.BUILD);
+
+        if (!job.isBuildable()) {
+            throw HttpResponses.error(SC_CONFLICT, new IOException(job.getFullName() + " is not buildable"));
+        }
+
+        if (delay == null) {
+            delay = new TimeDuration(TimeUnit.MILLISECONDS.convert(job.getQuietPeriod(), TimeUnit.SECONDS));
+        }
+
+        List<Action> actions = new ArrayList<>();
+        JSONObject formData;
+        try {
+            formData = req.getSubmittedForm();
+        }
+        catch (ServletException e) {
+            throw HttpResponses.error(SC_BAD_REQUEST,
+                    new IllegalArgumentException(
+                            "Missing or invalid contents of \"json\" form field: " + e.toString(), e));
+        }
+        try {
+            ParametersDefinitionProperty pp = job.getProperty(ParametersDefinitionProperty.class);
+            if (pp != null) {
+                Action paramAction = getParametersAction(req, formData, pp);
+                if (paramAction != null) {
+                    actions.add(paramAction);
+                }
+            }
+
+            List<Cause> causes = new ArrayList<>(Arrays.asList(getCallerCause(req)));
+            EiffelCause eiffelCause = getEiffelCause(formData);
+            if (eiffelCause != null) {
+                causes.add(eiffelCause);
+            }
+            actions.add(new CauseAction(causes));
+        }
+        catch (IllegalArgumentException e) {
+            throw HttpResponses.error(SC_BAD_REQUEST, e);
+        }
+
+        Queue.Item queuedBuild = Jenkins.get().getQueue().schedule2(job, delay.getTimeInSeconds(), actions).getItem();
+        if (queuedBuild != null) {
+            rsp.sendRedirect(SC_CREATED, req.getContextPath() + '/' + queuedBuild.getUrl());
+        } else {
+            rsp.sendRedirect(".");
+        }
+    }
+
+    /**
+     * Returns a {@link Cause} that indicates the caller that requested the build (either a
+     * {@link Cause.RemoteCause} or a {@link Cause.UserIdCause}).
+     * <p>
+     * The implementation was copied from
+     * {@link ParameterizedJobMixIn#getBuildCause(ParameterizedJobMixIn.ParameterizedJob, StaplerRequest)}
+     * and only slightly modified.
+     */
+    public Cause getCallerCause(StaplerRequest req) {
+        @SuppressWarnings("deprecation")
+        hudson.model.BuildAuthorizationToken authToken = job.getAuthToken();
+        if (authToken != null && authToken.getToken() != null && req.getParameter("token") != null) {
+            // Optional additional cause text when starting via token
+            String causeText = req.getParameter("cause");
+            return new Cause.RemoteCause(req.getRemoteAddr(), causeText);
+        } else {
+            return new Cause.UserIdCause();
+        }
+    }
+
+    /**
+     * Parses the posted form and transforms the supplied list of Eiffel event links
+     * into an {@link EiffelCause}. The JSON object in the form value must have a
+     * {@link #FORM_PARAM_EIFFELLINKS} key that contains the array of Eiffel links.
+     * The array may be empty in which case null is returned.
+     */
+    @CheckForNull
+    private EiffelCause getEiffelCause(final JSONObject formData) {
+        // This mixing of different parsed JSON representation isn't great, but the StaplerRequest
+        // provides us a JSONObject and we want to use Jackson for the events themselves.
+        try {
+            JSONArray eiffelLinks = formData.getJSONArray(FORM_PARAM_EIFFELLINKS);
+            ObjectMapper mapper = new ObjectMapper();
+            CollectionType listType = mapper.getTypeFactory().constructCollectionType(
+                    List.class, EiffelEvent.Link.class);
+            List<EiffelEvent.Link> links = mapper.readValue(eiffelLinks.toString(), listType);
+            return links.isEmpty() ? null : new EiffelCause(links);
+        }
+        catch (JSONException e) {
+            throw new IllegalArgumentException(String.format(
+                    "URL parameter '%s' did not contain a JSON array", FORM_PARAM_EIFFELLINKS), e);
+        }
+        catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(String.format(
+                    "URL parameter '%s' could not be deserialized into a list of Eiffel links: %s",
+                    FORM_PARAM_EIFFELLINKS, e.toString()), e);
+        }
+    }
+
+    /**
+     * Attempts to parse the posted form and transform the given build parameters and their
+     * values into a {@link ParametersAction}. The JSON object in the form value may have a
+     * {@link #FORM_PARAM_PARAMETERS} key that contains another object with the desired
+     * build parameters. If the {@link #FORM_PARAM_PARAMETERS} key is missing the default
+     * values of the parameters will be used. Returns null if no parameters were supplied.
+     */
+    @CheckForNull
+    private ParametersAction getParametersAction(final StaplerRequest req,
+                                                 final JSONObject formData,
+                                                 final ParametersDefinitionProperty pp) {
+        Object inputParams = formData.get(FORM_PARAM_PARAMETERS);
+        if (inputParams != null) {
+            List<ParameterValue> values = new ArrayList<>();
+            try {
+                for (Object paramObject : JSONArray.fromObject(inputParams)) {
+                    JSONObject param = (JSONObject) paramObject;
+                    String name = param.getString("name");
+
+                    ParameterDefinition paramDef = pp.getParameterDefinition(name);
+                    if (paramDef == null) {
+                        throw new IllegalArgumentException(String.format(
+                                "Build request provided a value for the '%s' parameter but the job has " +
+                                        "no parameter with that name", name));
+                    }
+                    ParameterValue parameterValue = paramDef.createValue(req, param);
+                    if (parameterValue != null) {
+                        values.add(parameterValue);
+                    } else {
+                        throw new IllegalArgumentException(String.format(
+                                "Cannot initialize the '%s' parameter with the given value", name));
+                    }
+                }
+                return values.isEmpty() ? null : new ParametersAction(values);
+            }
+            catch (ClassCastException | JSONException e) {
+                throw new IllegalArgumentException(String.format(
+                        "URL parameter '%s' couldn't be deserialized to a parameter list: %s",
+                        FORM_PARAM_PARAMETERS, e.toString()), e);
+            }
+        } else {
+            return new ParametersAction(
+                    pp.getParameterDefinitions().stream()
+                            .map(ParameterDefinition::getDefaultParameterValue)
+                            .filter(Objects::nonNull)
+                            .collect(Collectors.toList()));
+        }
+    }
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return URL_SUFFIX;
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionFreeStyleFactory.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionFreeStyleFactory.java
@@ -1,0 +1,52 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import jenkins.model.TransientActionFactory;
+
+/**
+ * Attaches the {@link BuildWithEiffelLinksAction} action to all {@link FreeStyleProject} instances.
+ */
+@Extension
+public class BuildWithEiffelLinksActionFreeStyleFactory extends TransientActionFactory<FreeStyleProject> {
+    /** {@inheritDoc} */
+    @Override
+    public Class<FreeStyleProject> type() {
+        return FreeStyleProject.class;
+    }
+
+    /** {@inheritDoc} */
+    @Nonnull
+    @Override
+    public Collection<? extends Action> createFor(@Nonnull FreeStyleProject job) {
+        return Collections.singleton(new BuildWithEiffelLinksAction(job));
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionWorkflowFactory.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionWorkflowFactory.java
@@ -1,0 +1,51 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.Extension;
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import java.util.Collection;
+import java.util.Collections;
+import javax.annotation.Nonnull;
+import jenkins.model.TransientActionFactory;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+
+/**
+ * Attaches the {@link BuildWithEiffelLinksAction} action to all {@link WorkflowJob} instances.
+ */
+@Extension(optional = true)
+public class BuildWithEiffelLinksActionWorkflowFactory extends TransientActionFactory<WorkflowJob> {
+    @Override
+    public Class<WorkflowJob> type() {
+        return WorkflowJob.class;
+    }
+
+    @Nonnull
+    @Override
+    public Collection<? extends Action> createFor(@Nonnull WorkflowJob job) {
+        return Collections.singleton(new BuildWithEiffelLinksAction(job));
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelCause.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelCause.java
@@ -1,0 +1,53 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import hudson.model.Cause;
+import java.util.List;
+import javax.annotation.Nonnull;
+
+/**
+ * Indicates that a build was started because of one or more Eiffel events.
+ */
+public class EiffelCause extends Cause {
+    private List<EiffelEvent.Link> links;
+
+    public EiffelCause(@Nonnull List<EiffelEvent.Link> links) {
+        this.links = links;
+    }
+
+    /** Returns the Eiffel links associated with this cause. */
+    @Nonnull
+    public List<EiffelEvent.Link> getLinks() {
+        return links;
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getShortDescription() {
+        return "Eiffel: " + links.toString();
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
@@ -1,0 +1,276 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gargoylesoftware.htmlunit.HttpMethod;
+import com.gargoylesoftware.htmlunit.WebRequest;
+import com.gargoylesoftware.htmlunit.WebResponse;
+import com.gargoylesoftware.htmlunit.util.NameValuePair;
+import hudson.model.AbstractBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static javax.servlet.http.HttpServletResponse.SC_CREATED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class BuildWithEiffelLinksActionTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    public WebResponse postBuildRequest(final Job job, final String jsonPayload) throws IOException {
+        JenkinsRule.WebClient wc = jenkins.createWebClient();
+        wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
+        URL url = wc.createCrumbedUrl(job.getUrl() + BuildWithEiffelLinksAction.URL_SUFFIX + "/build");
+        WebRequest req = new WebRequest(url, HttpMethod.POST);
+        if (jsonPayload != null) {
+            req.setRequestParameters(Arrays.asList(new NameValuePair("json", jsonPayload)));
+        }
+        return wc.getPage(req).getWebResponse();
+    }
+
+    @Test
+    public void testNonParameterizedFreestyleBuild_WithoutParams() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+
+        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_CREATED));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(notNullValue()));
+
+        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        assertThat(cause, is(notNullValue()));
+        assertThat(cause.getLinks(), is(reqParams.links));
+
+        ParametersAction paramAction = build.getAction(ParametersAction.class);
+        assertThat(paramAction, is(nullValue()));
+    }
+
+    @Test
+    public void testNonParameterizedFreestyleBuild_WithoutParams_WithoutLinks() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+        // Clear the links that are added by the constructor. The empty list
+        // will be omitted when the object is serialized to JSON.
+        reqParams.links.clear();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+
+        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(nullValue()));
+    }
+
+    @Test
+    public void testParameterizedFreestyleBuild_WithParams() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+        reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
+
+        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_CREATED));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(notNullValue()));
+
+        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        assertThat(cause, is(notNullValue()));
+        assertThat(cause.getLinks(), is(reqParams.links));
+
+        ParametersAction paramAction = build.getAction(ParametersAction.class);
+        assertThat(paramAction, is(notNullValue()));
+        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
+        assertThat(actualParam, is(notNullValue()));
+        assertThat(actualParam.getValue(), is("overridden value"));
+    }
+
+    @Test
+    public void testParameterizedWorkflowBuild_WithParams() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+        reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
+
+        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_CREATED));
+
+        WorkflowRun build = job.getBuildByNumber(1);
+        assertThat(build, is(notNullValue()));
+
+        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        assertThat(cause, is(notNullValue()));
+        assertThat(cause.getLinks(), is(reqParams.links));
+
+        ParametersAction paramAction = build.getAction(ParametersAction.class);
+        assertThat(paramAction, is(notNullValue()));
+        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
+        assertThat(actualParam, is(notNullValue()));
+        assertThat(actualParam.getValue(), is("overridden value"));
+    }
+
+    @Test
+    public void testParameterizedFreestyleBuild_WithBadJsonPayload() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+
+        WebResponse resp = postBuildRequest(job, "this is not valid JSON");
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(nullValue()));
+    }
+
+    @Test
+    public void testParameterizedFreestyleBuild_WithBadParameterJson() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+        reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
+
+        WebResponse resp = postBuildRequest(job, String.format(
+                "{\"%s\": [], \"%s\": [[\"this can't be deserialized\"]]}",
+                BuildWithEiffelLinksAction.FORM_PARAM_EIFFELLINKS,
+                BuildWithEiffelLinksAction.FORM_PARAM_PARAMETERS));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(nullValue()));
+    }
+
+    @Test
+    public void testParameterizedFreestyleBuild_WithBadEiffelLinksJson() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+        reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
+
+        WebResponse resp = postBuildRequest(job, String.format(
+                "{\"%s\": [[\"this can't be deserialized\"]]}",
+                BuildWithEiffelLinksAction.FORM_PARAM_EIFFELLINKS));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(nullValue()));
+    }
+
+    @Test
+    public void testParameterizedFreestyleBuild_WithoutParams() throws Exception {
+        BuildRequestParams reqParams = new BuildRequestParams();
+
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        job.addProperty(new ParametersDefinitionProperty(stringParam));
+
+        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        jenkins.waitUntilNoActivity();
+
+        assertThat(resp.getStatusCode(), is(SC_CREATED));
+
+        AbstractBuild build = job.getBuildByNumber(1);
+        assertThat(build, is(notNullValue()));
+
+        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        assertThat(cause, is(notNullValue()));
+        assertThat(cause.getLinks(), is(reqParams.links));
+
+        ParametersAction paramAction = build.getAction(ParametersAction.class);
+        assertThat(paramAction, is(notNullValue()));
+        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
+        assertThat(actualParam, is(notNullValue()));
+        assertThat(actualParam.getValue(), is("value"));
+    }
+
+    /**
+     * Helper to construct the JSON object posted in the "json" form parameter. By default populated
+     * with a few Eiffel links.
+     */
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    static class BuildRequestParams {
+        @JsonProperty(BuildWithEiffelLinksAction.FORM_PARAM_EIFFELLINKS)
+        public final List<EiffelEvent.Link> links = new ArrayList<>();
+
+        @JsonProperty(BuildWithEiffelLinksAction.FORM_PARAM_PARAMETERS)
+        public final List<NameValuePair> buildParams = new ArrayList<>();
+
+        BuildRequestParams() {
+            links.add(new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE,
+                    new EiffelActivityTriggeredEvent("activity name").getMeta().getId()));
+            links.add(new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT,
+                    new EiffelActivityTriggeredEvent("activity name").getMeta().getId()));
+        }
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
@@ -1,0 +1,62 @@
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class QueueListenerImplTest {
+    @Test
+    public void testAddTriggerFromEiffelCause_AddsAllLinks() {
+        List<EiffelEvent.Link> links = Arrays.asList(
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, UUID.randomUUID()),
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, UUID.randomUUID()),
+                new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
+        EiffelCause cause = new EiffelCause(links);
+        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        QueueListenerImpl queueListener = new QueueListenerImpl();
+        queueListener.addTriggerFromEiffelCause(cause, event,
+                new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
+
+        assertThat(event.getLinks(), is(links));
+    }
+
+    @Test
+    public void testAddTriggerFromEiffelCause_NoTriggerForNonCauseLink() {
+        List<EiffelEvent.Link> links = Arrays.asList(
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, UUID.randomUUID()),
+                new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
+        EiffelCause cause = new EiffelCause(links);
+        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        QueueListenerImpl queueListener = new QueueListenerImpl();
+        queueListener.addTriggerFromEiffelCause(cause, event,
+                new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
+
+        assertThat(event.getData().getTriggers(), is(emptyIterable()));
+    }
+
+    @Test
+    public void testAddTriggerFromEiffelCause_TriggerForCauseLink() {
+        UUID cause1 = UUID.randomUUID();
+        UUID cause2 = UUID.randomUUID();
+        List<EiffelEvent.Link> links = Arrays.asList(
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause1),
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause2));
+        EiffelCause cause = new EiffelCause(links);
+        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        QueueListenerImpl queueListener = new QueueListenerImpl();
+        queueListener.addTriggerFromEiffelCause(cause, event,
+                new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
+
+        assertThat(event.getData().getTriggers(), not(emptyIterable()));
+        EiffelActivityTriggeredEvent.Data.Trigger trigger = event.getData().getTriggers().get(0);
+        assertThat(trigger.getType(), is(EiffelActivityTriggeredEvent.Data.Trigger.Type.EIFFEL_EVENT));
+        assertThat(trigger.getDescription(), containsString(cause1.toString()));
+        assertThat(trigger.getDescription(), containsString(cause2.toString()));
+    }
+}


### PR DESCRIPTION
A new EiffelCause cause containing Eiffel event links is recognized the queue listener and populates the ActT event.
    
The new $JOB_URL/eiffel/build API endpoint complements the regular /build endpoint but also recognizes an "eiffellinks" key that, specified, gets parsed and ends up in the EiffelCause passed to started build. This allows clients to add e.g. CONTEXT and CAUSE to the Jenkins-originating activities.

There's one known bug/limitation: The EiffelCause class doesn't `@Export` list of links, only the short description. This shouldn't be a problem since the equivalent information is available from the events stored in the EiffelActivityAction that's also connected    to the run.

Closes #9.