### PR TITLE
Inject environment variables in all builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ Read more about the Eiffel protocol on https://github.com/eiffel-community/eiffe
 ### Notes
 - Current versions of each event can be found in the getVersion() function in the [sourcecode.](https://github.com/Isacholm/EiffelBroadcaster/tree/master/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel)
 
+## Accessing emitted Eiffel events in builds
+If a build needs to emit Eiffel events of its own they should probably have
+a CONTEXT or CAUSE link to the build's EiffelActivityTriggeredEvent. The
+plugins injects the following environment variables with the contents of
+the previously sent events:
+* `EIFFEL_ACTIVITY_TRIGGERED`: The build's EiffelActivityTriggeredEvent event.
+* `EIFFEL_ACTIVITY_STARTED`: The build's EiffelActivityStartedEvent event.
+
 ## API
 The plugin will do its best to populate the emitted
 EiffelActivityTriggeredEvent with information taken from the causes of

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributor.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributor.java
@@ -1,0 +1,78 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.EnvVars;
+import hudson.Extension;
+import hudson.model.EnvironmentContributor;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.io.IOException;
+import javax.annotation.Nonnull;
+
+/**
+ * An {@link EnvironmentContributor} implementation that injects environment variables with the JSON payload of
+ * the {@link Run}'s {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}
+ * and {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityStartedEvent}. Theoretically
+ * also the {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityFinishedEvent} if this
+ * class for some reason is used for a completed Run.
+ */
+@Extension
+public class EiffelEnvironmentContributor extends EnvironmentContributor {
+    /**
+     * The name of the environment variable containing the
+     * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityFinishedEvent}.
+     */
+    public static final String ACTIVITY_FINISHED = "EIFFEL_ACTIVITY_FINISHED";
+
+    /**
+     * The name of the environment variable containing the
+     * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityStartedEvent}.
+     */
+    public static final String ACTIVITY_STARTED = "EIFFEL_ACTIVITY_STARTED";
+
+    /**
+     * The name of the environment variable containing the
+     * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}.
+     */
+    public static final String ACTIVITY_TRIGGERED = "EIFFEL_ACTIVITY_TRIGGERED";
+
+    @Override
+    public void buildEnvironmentFor(@Nonnull Run r, @Nonnull EnvVars envs, @Nonnull TaskListener listener)
+            throws IOException, InterruptedException {
+        EiffelActivityAction action = r.getAction(EiffelActivityAction.class);
+        if (action != null) {
+            envs.put(EiffelEnvironmentContributor.ACTIVITY_TRIGGERED, action.getTriggerEventJSON());
+            String startedEvent = action.getStartedEventJSON();
+            if (startedEvent != null) {
+                envs.put(EiffelEnvironmentContributor.ACTIVITY_STARTED, startedEvent);
+            }
+            String finishedEvent = action.getFinishedEventJSON();
+            if (finishedEvent != null) {
+                envs.put(EiffelEnvironmentContributor.ACTIVITY_FINISHED, finishedEvent);
+            }
+        }
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
@@ -1,0 +1,93 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EiffelEnvironmentContributorTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        new Mocks.RabbitMQConnectionMock();
+    }
+
+    @Test
+    public void testEnvironmentVariablesAreAvailable_FreeStyle() throws Exception {
+        FreeStyleProject job = jenkins.createFreeStyleProject("test");
+        CaptureEnvironmentBuilder capture = new CaptureEnvironmentBuilder();
+        job.getBuildersList().add(capture);
+        jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        FreeStyleBuild run = job.getBuildByNumber(1);
+        EiffelActivityAction activityAction = run.getAction(EiffelActivityAction.class);
+        assertThat(activityAction, is(notNullValue()));
+
+        assertThat(capture.getEnvVars().get(EiffelEnvironmentContributor.ACTIVITY_STARTED),
+                is(activityAction.getStartedEventJSON()));
+        assertThat(capture.getEnvVars().get(EiffelEnvironmentContributor.ACTIVITY_TRIGGERED),
+                is(activityAction.getTriggerEventJSON()));
+    }
+
+    @Test
+    public void testEnvironmentVariablesAreAvailable_Pipeline() throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        String pipelineCode = String.format(
+                "node {" +
+                        "  if (isUnix()) {" +
+                        "    sh('echo STARTED=$%s ; echo TRIGGER=$%s')" +
+                        "  } else {" +
+                        "    bat('echo STARTED=%%%s%% ; echo TRIGGER=%%%s%%')" +
+                        "  }" +
+                        "}",
+                EiffelEnvironmentContributor.ACTIVITY_STARTED,
+                EiffelEnvironmentContributor.ACTIVITY_TRIGGERED,
+                EiffelEnvironmentContributor.ACTIVITY_STARTED,
+                EiffelEnvironmentContributor.ACTIVITY_TRIGGERED);
+        job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
+        jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        WorkflowRun run = job.getBuildByNumber(1);
+        EiffelActivityAction activityAction = run.getAction(EiffelActivityAction.class);
+        assertThat(activityAction, is(notNullValue()));
+
+        jenkins.assertLogContains(String.format("STARTED=%s", activityAction.getStartedEventJSON()), run);
+        jenkins.assertLogContains(String.format("TRIGGER=%s", activityAction.getTriggerEventJSON()), run);
+    }
+}


### PR DESCRIPTION
The new pipeline step injects environment variables with the JSON payloads of run's activity events:
    
    withEiffelEnv {
        sh 'echo "Here is the trigger: $EIFFEL_ACTIVITY_TRIGGERED"'
    }
    
Variables are provided for the ActT and ActS events. A new build wrapper provides the same functionality for freestyle jobs. Fixes #20.