### PR TITLE
Update event versions to the Paris edition

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
@@ -45,7 +45,7 @@ public class EiffelActivityCanceledEvent extends EiffelEvent {
     private final Data data;
 
     public EiffelActivityCanceledEvent() {
-        super("EiffelActivityCanceledEvent", "1.1.0");
+        super("EiffelActivityCanceledEvent", "3.0.0");
         this.data = new EiffelActivityCanceledEvent.Data();
     }
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
@@ -49,7 +49,7 @@ public class EiffelActivityFinishedEvent extends EiffelEvent {
     private final Data data;
 
     public EiffelActivityFinishedEvent(@JsonProperty("data") Data data) {
-        super("EiffelActivityFinishedEvent", "1.1.0");
+        super("EiffelActivityFinishedEvent", "3.0.0");
         this.data = data;
     }
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
@@ -49,7 +49,7 @@ public class EiffelActivityStartedEvent extends EiffelEvent {
     private final Data data;
 
     public EiffelActivityStartedEvent() {
-        super("EiffelActivityStartedEvent", "1.1.0");
+        super("EiffelActivityStartedEvent", "4.0.0");
         this.data = new Data();
     }
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
@@ -47,7 +47,7 @@ public class EiffelActivityTriggeredEvent extends EiffelEvent {
     private final Data data;
 
     public EiffelActivityTriggeredEvent(@JsonProperty("data") Data data) {
-        super("EiffelActivityTriggeredEvent", "1.1.0");
+        super("EiffelActivityTriggeredEvent", "4.0.0");
         this.data = data;
     }
 


### PR DESCRIPTION
Previously we were still emitting events from the Toulouse edition. Changing to current version of the Act* events won't matter in practice since the only differences are in meta.security and data.source.serializer, neither of which is currently populated. Fixes #6.