### PR TITLE
EiffelJobTable: Make it thread-safe, fix memory leak, and clean it up in general

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
@@ -29,9 +29,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nonnull;
 
 /**
- * Contains eiffel event map for jobs {@link EiffelJobTable}.
- * This singleton table is used to store information about eiffel events that
- * are linked within the same job.
+ * Maintains a table that maps a Jenkins queue ids to the id of the
+ * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}
+ * that was sent when the build was enqueued. This is needed to link the resulting
+ * {@link hudson.model.Run} to the right trigger event.
  *
  * @author Isac Holm &lt;isac.holm@axis.com&gt;
  * @version 1.0
@@ -41,18 +42,12 @@ public final class EiffelJobTable {
     private static EiffelJobTable instance = null;
     private final ConcurrentHashMap<Long, UUID> table;
 
-    /**
-     * EiffelJobTable Constructor.
-     *
-     */
-     private EiffelJobTable() {
+    /** Private constructor. Use {@link #getInstance()} to obtain an object instance of this class. */
+    private EiffelJobTable() {
         this.table = new ConcurrentHashMap<Long, UUID>();
     }
 
-    /**
-     * Get singleton instance.
-     * @return class instance
-     */
+    /** Gets the singleton instance. */
     public static synchronized EiffelJobTable getInstance() {
         if (instance == null) {
             instance = new EiffelJobTable();
@@ -61,24 +56,19 @@ public final class EiffelJobTable {
     }
 
     /**
-     * Get last event on a given jenkinsID.
-     * @return eventId
-     * @param jenkinsID
-     * uniqe id of a jenkins job.
+     * Gets the id of the {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}
+     * for a given queue id, or null of no such mapping is known.
      */
-    public UUID getEventTrigger(@Nonnull Long jenkinsID) {
-        return table.get(jenkinsID);
+    public UUID getEventTrigger(@Nonnull Long queueId) {
+        return table.get(queueId);
     }
 
     /**
-     * Update table with a new event for the given jenkinsId.
-     * @param jenkinsID
-     * uniqe id of a jenkins job.
-     * @param eiffelEventID
-     * uniqe id of an eiffel event.
-     */
-    public void setEventTrigger(@Nonnull Long jenkinsID, @Nonnull UUID eiffelEventID) {
-        table.put(jenkinsID, eiffelEventID);
+     * Update the table with a new mapping from a queue id to the id of a
+     * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}.
+     * */
+    public void setEventTrigger(@Nonnull Long queueId, @Nonnull UUID eiffelEventId) {
+        table.put(queueId, eiffelEventId);
     }
 
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
@@ -24,8 +24,9 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
-import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nonnull;
 
 /**
  * Contains eiffel event map for jobs {@link EiffelJobTable}.
@@ -38,21 +39,21 @@ import java.util.UUID;
  */
 public final class EiffelJobTable {
     private static EiffelJobTable instance = null;
-    private HashMap<Long, UUID> table;
+    private final ConcurrentHashMap<Long, UUID> table;
 
     /**
      * EiffelJobTable Constructor.
      *
      */
      private EiffelJobTable() {
-        this.table = new HashMap<Long, UUID>();
+        this.table = new ConcurrentHashMap<Long, UUID>();
     }
 
     /**
      * Get singleton instance.
      * @return class instance
      */
-    public static EiffelJobTable getInstance() {
+    public static synchronized EiffelJobTable getInstance() {
         if (instance == null) {
             instance = new EiffelJobTable();
         }
@@ -63,7 +64,8 @@ public final class EiffelJobTable {
      * Get table HashMap method.
      * @return HashMap
      */
-    private HashMap<Long, UUID> getTable() {
+    @Nonnull
+    private ConcurrentHashMap<Long, UUID> getTable() {
         return table;
     }
 
@@ -73,7 +75,7 @@ public final class EiffelJobTable {
      * @param jenkinsID
      * uniqe id of a jenkins job.
      */
-    public UUID getEventTrigger(Long jenkinsID) {
+    public UUID getEventTrigger(@Nonnull Long jenkinsID) {
         return getTable().get(jenkinsID);
     }
 
@@ -84,7 +86,7 @@ public final class EiffelJobTable {
      * @param eiffelEventID
      * uniqe id of an eiffel event.
      */
-    public void setEventTrigger(Long jenkinsID, UUID eiffelEventID) {
+    public void setEventTrigger(@Nonnull Long jenkinsID, @Nonnull UUID eiffelEventID) {
         getTable().put(jenkinsID, eiffelEventID);
     }
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
@@ -64,6 +64,14 @@ public final class EiffelJobTable {
     }
 
     /**
+     * Gets the id of the {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}
+     * for a given queue id, or null if no such mapping is known, and immediately clears that entry from the table.
+     */
+     public UUID getAndClearEventTrigger(@Nonnull Long queueId) {
+         return table.remove(queueId);
+     }
+
+    /**
      * Update the table with a new mapping from a queue id to the id of a
      * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent}.
      * */

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelJobTable.java
@@ -61,22 +61,13 @@ public final class EiffelJobTable {
     }
 
     /**
-     * Get table HashMap method.
-     * @return HashMap
-     */
-    @Nonnull
-    private ConcurrentHashMap<Long, UUID> getTable() {
-        return table;
-    }
-
-    /**
      * Get last event on a given jenkinsID.
      * @return eventId
      * @param jenkinsID
      * uniqe id of a jenkins job.
      */
     public UUID getEventTrigger(@Nonnull Long jenkinsID) {
-        return getTable().get(jenkinsID);
+        return table.get(jenkinsID);
     }
 
     /**
@@ -87,7 +78,7 @@ public final class EiffelJobTable {
      * uniqe id of an eiffel event.
      */
     public void setEventTrigger(@Nonnull Long jenkinsID, @Nonnull UUID eiffelEventID) {
-        getTable().put(jenkinsID, eiffelEventID);
+        table.put(jenkinsID, eiffelEventID);
     }
 
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
@@ -100,7 +100,7 @@ public class QueueListenerImpl extends QueueListener {
     @Override
     public void onLeft(Queue.LeftItem li) {
         if (li.isCancelled()) {
-            UUID targetEvent = EiffelJobTable.getInstance().getEventTrigger(li.getId());
+            UUID targetEvent = EiffelJobTable.getInstance().getAndClearEventTrigger(li.getId());
             if (targetEvent == null) {
                 logger.debug("A cancelled queue item could not be mapped to an emitted ActT event: {}", li);
                 return;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
@@ -68,6 +68,10 @@ public class RunListenerImpl extends RunListener<Run> {
     @Override
     public void onStarted(Run r, TaskListener listener) {
         UUID targetEvent = EiffelJobTable.getInstance().getAndClearEventTrigger(r.getQueueId());
+        if (targetEvent == null) {
+            logger.warn("The newly started {} could not be mapped to an emitted ActT event", r);
+            return;
+        }
         EiffelActivityStartedEvent event = new EiffelActivityStartedEvent(targetEvent);
 
         URI runUri = getRunUri(r);

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
@@ -67,7 +67,7 @@ public class RunListenerImpl extends RunListener<Run> {
 
     @Override
     public void onStarted(Run r, TaskListener listener) {
-        UUID targetEvent = EiffelJobTable.getInstance().getEventTrigger(r.getQueueId());
+        UUID targetEvent = EiffelJobTable.getInstance().getAndClearEventTrigger(r.getQueueId());
         EiffelActivityStartedEvent event = new EiffelActivityStartedEvent(targetEvent);
 
         URI runUri = getRunUri(r);


### PR DESCRIPTION
This commit stack makes various improvements to EiffelJobTable and its call sites, including but not limited to making the class thread-safe and getting rid of the memory leak (which fixes #22). Looking at the whole PR at once will not make much sense but I've made the commits quite small and self-contained so I strongly recommend looking at them one by one.