### PR TITLE
Populate meta.source.serializer with the package URL of the plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,14 @@
         <jackson2-api.version>2.11.1</jackson2-api.version>
         <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
         <jmockit.version>1.41</jmockit.version>
+        <packageurl.version>1.2.0</packageurl.version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>com.github.package-url</groupId>
+            <artifactId>packageurl-java</artifactId>
+            <version>${packageurl.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.rabbitmq</groupId>
             <artifactId>amqp-client</artifactId>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -26,6 +26,9 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SourceProvider;
+import com.github.packageurl.MalformedPackageURLException;
+import com.github.packageurl.PackageURL;
+import com.github.packageurl.PackageURLBuilder;
 import hudson.Plugin;
 import hudson.PluginWrapper;
 import java.net.InetAddress;
@@ -60,6 +63,7 @@ public class JenkinsSourceProvider implements SourceProvider {
 
     private String host;
     private String name;
+    private String serializer;
     private URI uri;
 
     public JenkinsSourceProvider() {
@@ -77,6 +81,17 @@ public class JenkinsSourceProvider implements SourceProvider {
                         logger.error("Error parsing plugin URL", e);
                     }
                 }
+
+                try {
+                    serializer = PackageURLBuilder.aPackageURL()
+                            .withType(PackageURL.StandardTypes.MAVEN)
+                            .withNamespace(pluginWrapper.getManifest().getMainAttributes().getValue("Group-Id"))
+                            .withName(pluginWrapper.getShortName())
+                            .withVersion(pluginWrapper.getVersion())
+                            .build().toString();
+                } catch (MalformedPackageURLException e) {
+                    logger.error("Error creating package URL", e);
+                }
             }
         }
     }
@@ -86,6 +101,7 @@ public class JenkinsSourceProvider implements SourceProvider {
     public void populateSource(@Nonnull EiffelEvent.Meta.Source source) {
         source.setHost(getHost());
         source.setName(name);
+        source.setSerializer(serializer);
         source.setUri(uri);
     }
 

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
@@ -25,6 +25,7 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.github.packageurl.PackageURL;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,6 +48,11 @@ public class JenkinsSourceProviderTest {
         EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
         assertThat(event.getMeta().getSource(), is(notNullValue()));
         assertThat(event.getMeta().getSource().getName(), is("Eiffel Broadcaster Plugin"));
+        assertThat(event.getMeta().getSource().getSerializer(), is(notNullValue()));
+        PackageURL purl = new PackageURL(event.getMeta().getSource().getSerializer());
+        assertThat(purl.getType(), is("maven"));
+        assertThat(purl.getNamespace(), is("com.axis.jenkins.plugins.eiffel"));
+        assertThat(purl.getName(), is("eiffel-broadcaster"));
         // Not testing meta.source.uri since it isn't available during tests.
         // Not testing meta.source.host to avoid test flakiness.
     }


### PR DESCRIPTION
The main point of including the package URL of this plugin is to get the plugin version which isn't included in meta.source.name or elsewhere.