### PR TITLE
Add support for setting data.categories member in ActT events

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,23 @@ the previously sent events:
 ## Category configuration
 
 The contents of the `data.categories` member in EiffelActivityTriggeredEvent
-is configurable with a global plugin setting. This can e.g. be used to
-distinguish Eiffel activities that represent Jenkins builds from other kinds
-of activities.  
+is configurable in two ways:
+
+* A global plugin setting.
+* A setting in each job, configured via the UI or the `eiffelActivity` pipeline
+  property:
+```
+properties([
+    eiffelActivity(categories: ['jenkins', 'maven'])
+])
+```
+
+Categories can e.g. be used to distinguish Eiffel activities that represent
+Jenkins builds from other kinds of activities, or distinguish between
+different kinds of Jenkins builds.
+
+Globally configured categories will be merged with the categories specified
+in each job. Duplicate entries will be eliminated.
 
 ## API
 The plugin will do its best to populate the emitted

--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ the previously sent events:
 * `EIFFEL_ACTIVITY_TRIGGERED`: The build's EiffelActivityTriggeredEvent event.
 * `EIFFEL_ACTIVITY_STARTED`: The build's EiffelActivityStartedEvent event.
 
+## Category configuration
+
+The contents of the `data.categories` member in EiffelActivityTriggeredEvent
+is configurable with a global plugin setting. This can e.g. be used to
+distinguish Eiffel activities that represent Jenkins builds from other kinds
+of activities.  
+
 ## API
 The plugin will do its best to populate the emitted
 EiffelActivityTriggeredEvent with information taken from the causes of

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>com.axis.jenkins.plugins.eiffel</groupId>
     <artifactId>eiffel-broadcaster</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Eiffel Broadcaster Plugin</name>
     <description>Broadcasts Eiffel messages on an MQ server</description>
@@ -68,6 +68,7 @@
         <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
         <jmockit.version>1.41</jmockit.version>
         <packageurl.version>1.2.0</packageurl.version>
+        <workflow-multibranch.version>2.21</workflow-multibranch.version>
     </properties>
     <dependencies>
         <dependency>
@@ -124,6 +125,12 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <version>${workflow-multibranch.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jmockit</groupId>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
@@ -1,0 +1,82 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import hudson.Extension;
+import hudson.model.Job;
+import java.util.List;
+import jenkins.model.OptionalJobProperty;
+import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.StaplerRequest;
+
+/**
+ * An {@link OptionalJobProperty} that can be used to populate additional members in
+ * in the Eiffel activity events emitted for the builds of a job.
+ * <p>
+ * Also defines a <tt>eiffelActivity</tt> pipeline step that can be used to set
+ * the properties via pipeline code:
+ * <pre>
+ * properties([
+ *     eiffelActivity(categories: ['a', 'b'])
+ * ])
+ * </pre>
+ */
+public class EiffelActivityJobProperty extends OptionalJobProperty<Job<?, ?>> {
+    private List<String> categories;
+
+    @DataBoundConstructor
+    public EiffelActivityJobProperty(final List<String> categories) {
+        this.categories = categories;
+    }
+
+    public List<String> getCategories() {
+        return categories;
+    }
+
+    @DataBoundSetter
+    public void setCategories(final List<String> categories) {
+        this.categories = categories;
+    }
+
+    @Extension
+    @Symbol("eiffelActivity")
+    public static class EiffelActivityJobPropertyDescriptor extends OptionalJobPropertyDescriptor {
+        @Override
+        public String getDisplayName() {
+            return "Eiffel activity attributes";
+        }
+
+        @Override
+        public OptionalJobProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            // The form uses a textarea for the categories but we split out the lines and store
+            // them individually in a list so we need to override the Stapler's default behavior.
+            List<String> categories = Util.getLinesInString(formData.getString("categories"));
+            return new EiffelActivityJobProperty(categories);
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -28,18 +28,19 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.client.PossibleAuthenticationFailureException;
-
 import hudson.Extension;
 import hudson.Plugin;
 import hudson.model.Describable;
 import hudson.model.Descriptor;
 import hudson.util.FormValidation;
 import hudson.util.Secret;
-
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.ServletException;
 import jenkins.model.Jenkins;
-
 import net.sf.json.JSONObject;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -48,10 +49,6 @@ import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.servlet.ServletException;
-import java.io.IOException;
-import java.net.URISyntaxException;
 
 /**
  * Adds the EiffelBroadcaster plugin configuration to the system config page.
@@ -88,6 +85,8 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
     private boolean persistentDelivery;
     /* Application id that can be read by the consumer (optional). */
     private String appId;
+    /* A list of strings representing categories to include in the ActTs. */
+    private final List<String> activityCategories = new ArrayList<>();
 
     /**
      * Creates an instance with specified parameters.
@@ -105,7 +104,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
     @DataBoundConstructor
     public EiffelBroadcasterConfig(boolean enableBroadcaster, String serverUri, String userName, Secret userPassword,
                             String exchangeName, String virtualHost, String routingKey, boolean persistentDelivery,
-                            String appId) {
+                            String appId, String activityCategories) {
         this.enableBroadcaster = enableBroadcaster;
         this.serverUri = serverUri;
         this.userName = userName;
@@ -115,6 +114,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
         this.routingKey = routingKey;
         this.persistentDelivery = persistentDelivery;
         this.appId = appId;
+        this.activityCategories.addAll(Util.getLinesInString(activityCategories));
     }
 
     @Override
@@ -323,6 +323,21 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
         this.appId = appId;
     }
 
+    /** Returns the list of categories to attach to the activities, expressed as a multi-line string. */
+    public String getActivityCategories() {
+        return StringUtils.join(this.activityCategories, '\n');
+    }
+
+    /** Returns the list of categories to attach to the activities. */
+    public List<String> getActivityCategoriesList() {
+        return this.activityCategories;
+    }
+
+    /** Sets the list of categories to attach to the activities. */
+    public void setActivityCategories(String activityCategories) {
+        this.activityCategories.clear();
+        this.activityCategories.addAll(Util.getLinesInString(activityCategories));
+    }
 
     /**
      * Returns the descriptor instance.

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
@@ -37,6 +37,8 @@ import hudson.model.queue.QueueListener;
 import hudson.triggers.SCMTrigger;
 import hudson.triggers.TimerTrigger;
 import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -67,6 +69,12 @@ public class QueueListenerImpl extends QueueListener {
         EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent(data);
         EiffelJobTable.getInstance().setEventTrigger(wi.getId(), event.getMeta().getId());
 
+        // Populate activity categories
+        SortedSet<String> categories = new TreeSet<>();
+        categories.addAll(EiffelBroadcasterConfig.getInstance().getActivityCategoriesList());
+        data.getCategories().addAll(categories);
+
+        // Populate causes
         for (Cause cause : wi.getCauses()) {
             // Default to OTHER as the default trigger type and override it for specific known causes.
             EiffelActivityTriggeredEvent.Data.Trigger trigger = new EiffelActivityTriggeredEvent.Data.Trigger(

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImpl.java
@@ -31,6 +31,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import hudson.Extension;
 import hudson.model.BuildableItem;
 import hudson.model.Cause;
+import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Run;
 import hudson.model.queue.QueueListener;
@@ -71,7 +72,19 @@ public class QueueListenerImpl extends QueueListener {
 
         // Populate activity categories
         SortedSet<String> categories = new TreeSet<>();
+
+        // ...with globally configured categories
         categories.addAll(EiffelBroadcasterConfig.getInstance().getActivityCategoriesList());
+
+        // ...with job-specific categories
+        if (wi.task instanceof Job<?, ?>) {
+            EiffelActivityJobProperty activityJobProperty =
+                    ((Job<?, ?>) wi.task).getProperty(EiffelActivityJobProperty.class);
+            if (activityJobProperty != null) {
+                categories.addAll(activityJobProperty.getCategories());
+            }
+        }
+
         data.getCategories().addAll(categories);
 
         // Populate causes

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -31,8 +31,10 @@ import com.rabbitmq.client.AMQP;
 import hudson.model.AbstractItem;
 import hudson.model.Queue;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,6 +95,23 @@ public final class Util {
                 logger.error("Unable to serialize object to JSON: {}: {}", e.getMessage(), event);
             }
         }
+    }
+
+    /**
+     * Splits the input string into lines, removes leading and trailing whitespace, and returns non-empty
+     * lines in a list.
+     *
+     * @param s the line to split
+     */
+    public static List<String> getLinesInString(String s) {
+        List<String> result = new ArrayList<>();
+        for (String line : s.split("\\R")) {  // \R is "any Unicode linebreak sequence"
+            String trimmed = line.trim();
+            if (!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty/config.groovy
@@ -1,0 +1,32 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelActivityJobProperty
+
+def f = namespace(lib.FormTagLib)
+def l = "/plugin/eiffel-broadcaster/"
+
+f.entry(title: 'Eiffel activity categories', field: 'categories', help: l+"help-activity-job-categories.html") {
+    f.textarea(value: instance == null ? '' : instance.categories.join('\n'))
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
@@ -59,4 +59,7 @@ f.section(title: "Eiffel Broadcaster Plugin") {
     f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
         f.checkbox(field: "persistentDelivery", checked: my.persistentDelivery)
     }
+    f.entry(title: "Activity Categories", field: "activityCategories", help: l+"help-activity-categories.html") {
+        f.textarea(value: my.activityCategories)
+    }
 }

--- a/src/main/webapp/help-activity-categories.html
+++ b/src/main/webapp/help-activity-categories.html
@@ -1,0 +1,7 @@
+<div>
+    A list of "category" strings, one per line, that all builds in this Jenkins instance
+    will be tagged with. Categories are stored in the <tt>data.categories</tt> member of emitted
+    <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityTriggeredEvent.md">EiffelActivityTriggeredEvent</a>
+    messages. Leading and trailing whitespace will be removed from each line. Duplicate lines and
+    empty lines will be ignored.
+</div>

--- a/src/main/webapp/help-activity-job-categories.html
+++ b/src/main/webapp/help-activity-job-categories.html
@@ -1,8 +1,8 @@
 <div>
-    A list of "category" strings, one per line, that all builds in this Jenkins instance
-    will be tagged with. Categories are stored in the <tt>data.categories</tt> member of emitted
+    A list of "category" strings, one per line, that builds of this job will be tagged with.
+    Categories are stored in the <tt>data.categories</tt> member of emitted
     <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelActivityTriggeredEvent.md">EiffelActivityTriggeredEvent</a>
-    messages. Categories listed here will be merged with any categories configured for each job.
+    messages. Categories listed here will be merged with any globally configured categories.
     Leading and trailing whitespace will be removed from each line. Duplicate lines and
     empty lines will be ignored.
 </div>

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -37,6 +37,7 @@ import hudson.model.CauseAction;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.tasks.BuildTrigger;
+import java.util.Arrays;
 import java.util.Collections;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -325,5 +326,28 @@ public class EmittedEventsTest {
         EiffelActivityFinishedEvent actF = action.getFinishedEvent();
         assertThat(actF, is(notNullValue()));
         assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
+    }
+
+    @Test
+    public void testActivityCategoriesForFreestyleBuildEmptyDefault() throws Exception {
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        assertThat(actT.getData().getCategories(), is(Collections.emptyList()));
+    }
+
+    @Test
+    public void testActivityCategoriesForFreestyleBuildUsesGlobalConfig() throws Exception {
+        EiffelBroadcasterConfig.getInstance().setActivityCategories("global category");
+        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        EventSet events = new EventSet(Mocks.messages);
+
+        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        assertThat(actT.getData().getCategories(), is(Arrays.asList("global category")));
     }
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/UtilTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/UtilTest.java
@@ -1,0 +1,58 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import java.util.Arrays;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class UtilTest {
+    @Test
+    public void testLinesToCollection_DuplicateLinesKept() {
+        assertThat(Util.getLinesInString("foo\nfoo"), is(Arrays.asList("foo", "foo")));
+    }
+
+    @Test
+    public void testLinesToCollection_EmptyString() {
+        assertThat(Util.getLinesInString(""), is(empty()));
+    }
+
+    @Test
+    public void testLinesToCollection_EmptyLinesIgnored() {
+        assertThat(Util.getLinesInString("foo\n\nbar\n\n"), is(Arrays.asList("foo", "bar")));
+    }
+
+    @Test
+    public void testLinesToCollection_MultipleLinesKept() {
+        assertThat(Util.getLinesInString("foo\nbar"), is(Arrays.asList("foo", "bar")));
+    }
+
+    @Test
+    public void testLinesToCollection_PrefixPostfixWhitespaceTrimmed() {
+        assertThat(Util.getLinesInString("  foo  "), is(Arrays.asList("foo")));
+    }
+}


### PR DESCRIPTION
Adds support for setting the `data.categories` member in ActT events, both globally and per-job via a new property. This can be used by consumers to distinguish Jenkins activities from other activities or distinguish between different kinds of Jenkins jobs. Fixes #17.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
