### PR TITLE
Don't include URL schemes array in serialized configuration

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -58,7 +58,8 @@ import org.slf4j.LoggerFactory;
 @Extension
 public final class EiffelBroadcasterConfig extends Plugin implements Describable<EiffelBroadcasterConfig> {
     private static final Logger logger = LoggerFactory.getLogger(EiffelBroadcasterConfig.class);
-    private final String[] schemes = {"amqp", "amqps"};
+    private transient final String[] schemes = {};  // Replaced by ALLOWED_URL_SCHEMES but retained to satisfy XStream
+    private static final String[] ALLOWED_URL_SCHEMES = {"amqp", "amqps"};
     private static final String SERVER_URI = "serverUri";
     private static final String USERNAME = "userName";
     private static final String PASSWORD = "userPassword";
@@ -377,7 +378,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
                                                @QueryParameter(USERNAME) final String name,
                                                @QueryParameter(PASSWORD) final Secret pw) throws ServletException {
             Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-            UrlValidator urlValidator = new UrlValidator(getInstance().schemes, UrlValidator.ALLOW_LOCAL_URLS);
+            UrlValidator urlValidator = new UrlValidator(ALLOWED_URL_SCHEMES, UrlValidator.ALLOW_LOCAL_URLS);
             FormValidation result = FormValidation.ok();
             if (urlValidator.isValid(uri)) {
                 Connection conn = null;


### PR DESCRIPTION
The string array containing the names of the acceptable URL schemes, EiffelBroadcasterConfig#schemes, was marked as "private final" which caused it to be serialized to the plugin's configuration file. No big deal, but it's wasteful and potentially confusing since the values aren't really configurable.

We make that attribute transient (i.e. XStream can deserialize into the attribute but will ignore it when serializing) and introduce a new ALLOWED_URL_SCHEMES constant that won't be serialized (since it's static).

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
