### PR TITLE
Fix logger name in JenkinsSourceProvider

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -53,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * be left empty forever.
  */
 public class JenkinsSourceProvider implements SourceProvider {
-    private static final Logger logger = LoggerFactory.getLogger(EiffelBroadcasterConfig.class);
+    private static final Logger logger = LoggerFactory.getLogger(JenkinsSourceProvider.class);
 
     /** How frequently to attempt to find out the current host's name. */
     private static final Duration HOST_CHECK_INTERVAL = Duration.ofMinutes(2);


### PR DESCRIPTION
Because of a copy/paste mistake in commit 107b3129 the JenkinsSourceProvider class incorrectly referenced the wrong class when creating the static class-wide logger.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
