### PR TITLE
Send ArtP based on ArtC emitted during the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ echo "Here's the resulting purl: ${purl}"
 
 The publishEiffelArtifacts pipeline step sends an EiffelArtifactPublishedEvent
 for each EiffelArtifactCreatedEvent that has been recorded in the build using
-a sendEiffelEvent step with the `publishArtifact` argument enabled.
+a sendEiffelEvent step with the `publishArtifact` argument enabled and for
+each artifact recorded in the specified JSON files in the workspace.
 
 This requires that each EiffelArtifactPublishedEvent has at least one file
 defined in its `data.fileInformation` array and that each relative file path
@@ -93,7 +94,11 @@ The EiffelArtifactPublishedEvent will have two links; one ARTIFACT link to
 the EiffelArtifactCreatedEvent and one CONTEXT link to the parent build's
 EiffelActivityTriggeredEvent.
 
-Example:
+| Argument            | Description                 |
+| --------------------|-----------------------------|
+| artifactEventFiles  | An Ant-style glob expression that selects files containing JSON representations (one per line) of EiffelArtifactCreatedEvent to publish. Optional. |
+
+Example of publishing artifacts connected to the build:
 ```
 def event = [
     'meta': [
@@ -113,6 +118,28 @@ sendEiffelEvent event: event, publishArtifact: true
 
 archiveArtifacts artifacts: 'myprogram-1.0.tar.gz'
 publishEiffelArtifacts()
+```
+
+Example of publishing artifacts from a file:
+```
+def event = [
+    'meta': [
+        'type': 'EiffelArtifactCreatedEvent',
+        'version': '3.0.0',
+    ],
+    'data': [
+        'identity': 'pkg:generic/myprogram@1.0',
+        'fileInformation': [
+            [
+                'name': 'myprogram-1.0.tar.gz',
+            ],
+        ],
+    ],
+]
+writeJSON file: 'events.json', json: event
+
+archiveArtifacts artifacts: 'myprogram-1.0.tar.gz'
+publishEiffelArtifacts artifactEventFiles: '*.json'
 ```
 
 ### sendEiffelEvent

--- a/README.md
+++ b/README.md
@@ -76,6 +76,45 @@ def purl = createPackageURL type: 'generic', namespace: 'name/space',
 echo "Here's the resulting purl: ${purl}"
 ```
 
+### publishEiffelArtifacts
+
+The publishEiffelArtifacts pipeline step sends an EiffelArtifactPublishedEvent
+for each EiffelArtifactCreatedEvent that has been recorded in the build using
+a sendEiffelEvent step with the `publishArtifact` argument enabled.
+
+This requires that each EiffelArtifactPublishedEvent has at least one file
+defined in its `data.fileInformation` array and that each relative file path
+in `data.fileInformation.name` matches a Jenkins artifact in the build.
+Because of the latter requirement it's normally used after an
+[archiveArtifacts](https://www.jenkins.io/doc/pipeline/steps/core/#code-archiveartifacts-code-archive-the-artifacts)
+step.
+
+The EiffelArtifactPublishedEvent will have two links; one ARTIFACT link to
+the EiffelArtifactCreatedEvent and one CONTEXT link to the parent build's
+EiffelActivityTriggeredEvent.
+
+Example:
+```
+def event = [
+    'meta': [
+        'type': 'EiffelArtifactCreatedEvent',
+        'version': '3.0.0',
+    ],
+    'data': [
+        'identity': 'pkg:generic/myprogram@1.0',
+        'fileInformation': [
+            [
+                'name': 'myprogram-1.0.tar.gz',
+            ],
+        ],
+    ],
+]
+sendEiffelEvent event: event, publishArtifact: true
+
+archiveArtifacts artifacts: 'myprogram-1.0.tar.gz'
+publishEiffelArtifacts()
+```
+
 ### sendEiffelEvent
 
 The sendEiffelEvent pipeline step sends an Eiffel event from that's built in
@@ -87,6 +126,7 @@ the following parameters:
 | event             | A map with the event payload. The `meta.id` and `meta.time` members will be populated automatically. |
 | linkToActivity    | If true (default) the event sent will automatically include link to the current build's EiffelActivityTriggeredEvent. Optional. |
 | activityLinkType  | The link type to use when linking to the EiffelActivityTriggeredEvent. Defaults to CONTEXT but can be set to CAUSE. Optional. |
+| publishArtifact   | If true and the event being sent is EiffelArtifactCreatedEvent it will be recorded for possible later use by the publishEiffelArtifacts step. Optional. |
 
 Example:
 ```

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
@@ -1,0 +1,114 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import hudson.Functions;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.List;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import jenkins.util.VirtualFile;
+
+/**
+ * Transforms an {@link EiffelArtifactCreatedEvent} with one or more files declared into an
+ * {@link EiffelArtifactPublishedEvent} that contains the URIs to the Jenkins artifacts that
+ * correspond to the Eiffel artifact's files.
+ */
+public class EiffelArtifactPublisher {
+    private final VirtualFile artifactRoot;
+    private final EiffelEvent contextEvent;
+    private final URI runURI;
+
+    /**
+     * Constructs a new object instance.
+     *
+     * @param contextEvent the event that the {@link EiffelArtifactPublishedEvent} should link to with a CONTEXT link
+     * @param runURI the {@link URI} of the {@link hudson.model.Run} that contains the files for the artifact
+     * @param artifactRoot a {@link VirtualFile} that represents the Jenkins artifact root directory
+     */
+    public EiffelArtifactPublisher(@Nonnull final EiffelEvent contextEvent,
+                                   @Nonnull final URI runURI,
+                                   @Nonnull final VirtualFile artifactRoot) {
+        this.contextEvent = contextEvent;
+        this.runURI = runURI;
+        this.artifactRoot = artifactRoot;
+    }
+
+    /**
+     * Prepares a {@link EiffelArtifactPublishedEvent} that's ready to be sent.
+     * @param creationEvent the {@link EiffelArtifactCreatedEvent} that should be published
+     * @throws EmptyArtifactException when the {@link EiffelArtifactCreatedEvent} doesn't contain any files
+     *                                in <tt>data.fileInformation</tt>
+     * @throws IOException when there was a problem correlating the files in the {@link EiffelArtifactCreatedEvent}
+     *                     with the files in the {@link hudson.model.Run}'s artifacts
+     * @throws MissingArtifactException when one or more of the files listed in
+     *                                  the {@link EiffelArtifactCreatedEvent}'s <tt>data.fileInformation</tt> array
+     *                                  doesn't exist in Jenkins's artifact directory
+     * @throws URISyntaxException when an error occurred when trying to construct a URI to an artifact file
+     */
+    public EiffelArtifactPublishedEvent prepareEvent(@Nonnull final EiffelArtifactCreatedEvent creationEvent)
+            throws EmptyArtifactException, IOException, MissingArtifactException, URISyntaxException {
+        // It's okay for an ArtC to not have any files in its data.fileInformation array but if we're
+        // explicitly asked to emit an ArtP for the artifact and we can't do that it's reasonable to fail.
+        if (creationEvent.getData().getFileInformation().isEmpty()) {
+            throw new EmptyArtifactException(creationEvent);
+        }
+
+        // Before creating an ArtP event, verify that all files specified in the ArtC (data.fileInformation)
+        // actually exist as Jenkins artifacts for the Run in question.
+        SortedSet<String> missingArtifacts = new TreeSet<>();
+        List<String> artifactFilenames = creationEvent.getData().getFileInformation().stream()
+                .map(EiffelArtifactCreatedEvent.Data.FileInformation::getName)
+                .collect(Collectors.toList());
+        for (String filename : artifactFilenames) {
+            if (!artifactRoot.child(filename).isFile() ) {
+                missingArtifacts.add(filename);
+            }
+        }
+        if (!missingArtifacts.isEmpty()) {
+            throw new MissingArtifactException(creationEvent, missingArtifacts);
+        }
+
+        // Sanity check okay, continue with the construction of the ArtP event.
+        EiffelArtifactPublishedEvent publishEvent = new EiffelArtifactPublishedEvent(creationEvent.getMeta().getId());
+        publishEvent.getLinks().add(
+                new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, contextEvent.getMeta().getId()));
+        for (EiffelArtifactCreatedEvent.Data.FileInformation fileInfo : creationEvent.getData().getFileInformation()) {
+            EiffelArtifactPublishedEvent.Data.Location location = new EiffelArtifactPublishedEvent.Data.Location(
+                    EiffelArtifactPublishedEvent.Data.Location.Type.PLAIN,
+                    new URI(Functions.joinPath(runURI.toString(), "artifact", fileInfo.getName())));
+            location.setName(fileInfo.getName());
+            publishEvent.getData().getLocations().add(location);
+        }
+        return publishEvent;
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactToPublishAction.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactToPublishAction.java
@@ -1,0 +1,78 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.model.Action;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * Stores information about an {@link EiffelArtifactCreatedEvent} in a {@link hudson.model.Run} so that a future
+ * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.PublishEiffelArtifactsStep} can construct and
+ * send an {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent} once
+ * the artifact is actually available for download.
+ */
+@ExportedBean
+public class EiffelArtifactToPublishAction implements Action {
+    private @Nonnull final String eventJSON;
+
+    public EiffelArtifactToPublishAction(@Nonnull EiffelArtifactCreatedEvent event) throws JsonProcessingException {
+        this.eventJSON = event.toJSON();
+    }
+
+    @Nonnull
+    public EiffelArtifactCreatedEvent getEvent() throws JsonProcessingException {
+        return new ObjectMapper().readValue(eventJSON, EiffelArtifactCreatedEvent.class);
+    }
+
+    @Exported
+    @Nonnull
+    public String getEventJSON() {
+        return eventJSON;
+    }
+
+    @CheckForNull
+    @Override
+    public String getIconFileName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getDisplayName() {
+        return null;
+    }
+
+    @CheckForNull
+    @Override
+    public String getUrlName() {
+        return null;
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmptyArtifactException.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmptyArtifactException.java
@@ -1,0 +1,42 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import javax.annotation.Nonnull;
+
+/**
+ * Raised when an {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent}
+ * can't be created from an {@link EiffelArtifactCreatedEvent} because the latter doesn't declare the names of
+ * the files that make up the artifact, making it impossible to create URIs for the files.
+ */
+public class EmptyArtifactException extends Exception {
+    public EmptyArtifactException(@Nonnull final EiffelArtifactCreatedEvent creationEvent) {
+        super(String.format(
+                "Unable to send EiffelArtifactPublishedEvent for Eiffel artifact with id %s and " +
+                        "identity %s because it didn't declare any files in data.fileInformation.",
+                creationEvent.getMeta().getId(), creationEvent.getData().getIdentity()));
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MissingArtifactException.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MissingArtifactException.java
@@ -1,0 +1,46 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import java.util.Collection;
+import javax.annotation.Nonnull;
+
+/**
+ * Raised when an {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent}
+ * can't be created from an {@link EiffelArtifactCreatedEvent} because one or more files declare in the latter
+ * doesn't exist as a Jenkins artifact for the build, making it impossible to create URIs for the Eiffel
+ * artifact's files.
+ */
+public class MissingArtifactException extends Exception {
+    public MissingArtifactException(@Nonnull final EiffelArtifactCreatedEvent creationEvent,
+                                    @Nonnull final Collection<String> missingArtifacts) {
+        super(String.format(
+                "Unable to send EiffelArtifactPublishedEvent for Eiffel artifact with id %s and " +
+                        "identity %s because the following files included in the Eiffel artifact " +
+                        "aren't available as Jenkins artifacts in this build: %s",
+                creationEvent.getMeta().getId(), creationEvent.getData().getIdentity(), missingArtifacts));
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
@@ -28,15 +28,12 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityFi
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityStartedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import hudson.Extension;
-import hudson.Functions;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.UUID;
-import jenkins.model.Jenkins;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,11 +71,11 @@ public class RunListenerImpl extends RunListener<Run> {
         }
         EiffelActivityStartedEvent event = new EiffelActivityStartedEvent(targetEvent);
 
-        URI runUri = getRunUri(r);
+        URI runUri = Util.getRunUri(r);
         if (runUri != null) {
             event.getData().setExecutionUri(runUri);
         }
-        URI logUri = getRunUri(r, CONSOLE_URI_PATH);
+        URI logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
         if (logUri != null) {
             event.getData().getLiveLogs().add(
                     new EiffelActivityStartedEvent.Data.LiveLogs(CONSOLE_LOG_NAME, logUri));
@@ -119,7 +116,7 @@ public class RunListenerImpl extends RunListener<Run> {
             return;
         }
 
-        URI logUri = getRunUri(r, CONSOLE_URI_PATH);
+        URI logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
         if (logUri != null) {
             event.getData().getPersistentLogs().add(
                     new EiffelActivityFinishedEvent.Data.PersistentLogs(CONSOLE_LOG_NAME, logUri));
@@ -132,28 +129,5 @@ public class RunListenerImpl extends RunListener<Run> {
             // to publish the event. No need to log the same error message twice.
         }
         Util.publishEvent(event);
-    }
-
-    /**
-     * Returns the URI of a {@link Run}, or one of its subresources.
-     *
-     * @param r the Run to return the URI for
-     * @param pathSuffix additional path components to append
-     * @return the URI asked for, or null if a URI couldn't be resolved
-     */
-    private static URI getRunUri(Run r, String... pathSuffix) {
-        Jenkins jenkins = Jenkins.get();
-        if (jenkins.getRootUrl() != null) {
-            try {
-                String uri = Functions.joinPath(jenkins.getRootUrl(), r.getUrl());
-                if (pathSuffix.length == 0) {
-                    return new URI(uri);
-                }
-                return new URI(Functions.joinPath(uri, Functions.joinPath(pathSuffix)));
-            } catch (URISyntaxException e) {
-                logger.warn("Error constructing URI for build", e);
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -32,14 +32,19 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP;
+import hudson.Functions;
 import hudson.model.AbstractItem;
 import hudson.model.Queue;
+import hudson.model.Run;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -82,6 +87,29 @@ public final class Util {
         } else {
             return t.getName();
         }
+    }
+
+    /**
+     * Returns the URI of a {@link Run}, or one of its subresources.
+     *
+     * @param r the Run to return the URI for
+     * @param pathSuffix additional path components to append
+     * @return the URI asked for, or null if a URI couldn't be resolved
+     */
+    public static URI getRunUri(final Run r, String... pathSuffix) {
+        Jenkins jenkins = Jenkins.get();
+        if (jenkins.getRootUrl() != null) {
+            try {
+                String uri = Functions.joinPath(jenkins.getRootUrl(), r.getUrl());
+                if (pathSuffix.length == 0) {
+                    return new URI(uri);
+                }
+                return new URI(Functions.joinPath(uri, Functions.joinPath(pathSuffix)));
+            } catch (URISyntaxException e) {
+                logger.warn("Error constructing URI for build", e);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
@@ -1,0 +1,234 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactCreatedEvent.md">
+ * EiffelArtifactCreatedEvent</a> (ArtC) kind.
+ *
+ * See the Eiffel event documentation for more on the meaning of the attributes.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
+public class EiffelArtifactCreatedEvent extends EiffelEvent {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final EiffelArtifactCreatedEvent.Data data;
+
+    public EiffelArtifactCreatedEvent(@JsonProperty("data") Data data) {
+        super("EiffelArtifactCreatedEvent", "3.0.0");
+        this.data = data;
+    }
+
+    public EiffelArtifactCreatedEvent(String identity) {
+        this(new Data(identity));
+    }
+
+    public EiffelArtifactCreatedEvent.Data getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelArtifactCreatedEvent that = (EiffelArtifactCreatedEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private String identity;
+
+        private List<FileInformation> fileInformation = new ArrayList<>();
+
+        private String buildCommand;
+
+        private RequiresImplementation requiresImplementation;
+
+        @JsonProperty("implements")
+        private List<String> implementsPurls = new ArrayList<>();
+
+        private List<String> dependsOn = new ArrayList<>();;
+
+        private String name;
+
+        public Data(@JsonProperty("identity") String identity) {
+            this.identity = identity;
+        }
+
+        public String getIdentity() {
+            return identity;
+        }
+
+        public void setIdentity(String identity) {
+            this.identity = identity;
+        }
+
+        public List<FileInformation> getFileInformation() {
+            return fileInformation;
+        }
+
+        public String getBuildCommand() {
+            return buildCommand;
+        }
+
+        public void setBuildCommand(String buildCommand) {
+            this.buildCommand = buildCommand;
+        }
+
+        public RequiresImplementation getRequiresImplementation() {
+            return requiresImplementation;
+        }
+
+        public void setRequiresImplementation(RequiresImplementation requiresImplementation) {
+            this.requiresImplementation = requiresImplementation;
+        }
+
+        public List<String> getImplementsPurls() {
+            return implementsPurls;
+        }
+
+        public List<String> getDependsOn() {
+            return dependsOn;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public enum RequiresImplementation {
+            NONE,
+            ANY,
+            EXACTLY_ONE,
+            AT_LEAST_ONE
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return identity.equals(data.identity) && fileInformation.equals(data.fileInformation) &&
+                    Objects.equals(buildCommand, data.buildCommand) &&
+                    requiresImplementation == data.requiresImplementation &&
+                    implementsPurls.equals(data.implementsPurls) && dependsOn.equals(data.dependsOn) &&
+                    Objects.equals(name, data.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(identity, fileInformation, buildCommand, requiresImplementation,
+                    implementsPurls, dependsOn, name);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("identity", identity)
+                    .append("fileInformation", fileInformation)
+                    .append("buildCommand", buildCommand)
+                    .append("requiresImplementation", requiresImplementation)
+                    .append("implementsPurls", implementsPurls)
+                    .append("dependsOn", dependsOn)
+                    .append("name", name)
+                    .toString();
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class FileInformation {
+            @JsonInclude(JsonInclude.Include.ALWAYS)
+            private String name;
+
+            private List<String> tags = new ArrayList<>();
+
+            public FileInformation(@JsonProperty("name") String name) {
+                this.name = name;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public List<String> getTags() {
+                return tags;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                FileInformation that = (FileInformation) o;
+                return name.equals(that.name) && tags.equals(that.tags);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(name, tags);
+            }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("name", name)
+                        .append("tags", tags)
+                        .toString();
+            }
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactPublishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactPublishedEvent.java
@@ -1,0 +1,182 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * A Java representation of an Eiffel event of the
+ * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactPublishedEvent.md">
+ * EiffelArtifactPublishedEvent</a> (ArtC) kind.
+ *
+ * See the Eiffel event documentation for more on the meaning of the attributes.
+ */
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+@JsonDeserialize(using = JsonDeserializer.None.class)
+public class EiffelArtifactPublishedEvent extends EiffelEvent {
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    private final EiffelArtifactPublishedEvent.Data data;
+
+    public EiffelArtifactPublishedEvent() {
+        super("EiffelArtifactPublishedEvent", "3.1.0");
+        this.data = new Data();
+    }
+
+    public EiffelArtifactPublishedEvent(UUID artifactID) {
+        this();
+        getLinks().add(new Link(Link.Type.ARTIFACT, artifactID));
+    }
+
+    public EiffelArtifactPublishedEvent.Data getData() {
+        return data;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        EiffelArtifactPublishedEvent that = (EiffelArtifactPublishedEvent) o;
+        return data.equals(that.data);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), data);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("links", getLinks())
+                .append("meta", getMeta())
+                .append("data", data)
+                .toString();
+    }
+
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public static class Data {
+        @JsonInclude(JsonInclude.Include.ALWAYS)
+        private List<Location> locations = new ArrayList<>();
+
+        public List<Location> getLocations() {
+            return locations;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Data data = (Data) o;
+            return locations.equals(data.locations);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(locations);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .append("locations", locations)
+                    .toString();
+        }
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        public static class Location {
+            private Type type;
+            private String name;
+            private URI uri;
+
+            public Location(@JsonProperty("type") Type type, @JsonProperty("uri") URI uri) {
+                this.type = type;
+                this.uri = uri;
+            }
+
+            public Type getType() {
+                return type;
+            }
+
+            public void setType(Type type) {
+                this.type = type;
+            }
+
+            public String getName() {
+                return name;
+            }
+
+            public void setName(String name) {
+                this.name = name;
+            }
+
+            public URI getUri() {
+                return uri;
+            }
+
+            public void setUri(URI uri) {
+                this.uri = uri;
+            }
+
+            @Override
+            public boolean equals(Object o) {
+                if (this == o) return true;
+                if (o == null || getClass() != o.getClass()) return false;
+                Location location = (Location) o;
+                return type == location.type && Objects.equals(name, location.name) && uri.equals(location.uri);
+            }
+
+            @Override
+            public int hashCode() {
+                return Objects.hash(type, name, uri);
+            }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("type", type)
+                        .append("name", name)
+                        .append("uri", uri)
+                        .toString();
+            }
+
+            public enum Type {
+                ARTIFACTORY,
+                NEXUS,
+                PLAIN,
+                OTHER
+            }
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep.java
@@ -1,0 +1,129 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelActivityAction;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelArtifactPublisher;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelArtifactToPublishAction;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EmptyArtifactException;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.MissingArtifactException;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Util;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
+import hudson.AbortException;
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.steps.Step;
+import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
+import org.jenkinsci.plugins.workflow.steps.StepExecution;
+import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Pipeline step for publishing previously announced Eiffel artifacts, i.e. sending
+ * an {@link EiffelArtifactPublishedEvent} that contains URIs to the Jenkins artifacts that correspond to
+ * the files in the Eiffel artifact. The artifact creation events are picked up from the {@link Run}'s
+ * {@link EiffelArtifactToPublishAction} actions, optionally added by {@link SendEiffelEventStep}.
+ */
+public class PublishEiffelArtifactsStep extends Step {
+    public static final String ERROR_MESSAGE_PREFIX = "Could not publish Eiffel event";
+
+    @DataBoundConstructor
+    public PublishEiffelArtifactsStep() { }
+
+    @Override
+    public StepExecution start(StepContext stepContext) throws Exception {
+        return new Execution(this, stepContext);
+    }
+
+    private static class Execution extends SynchronousStepExecution<Void> {
+        private static final long serialVersionUID = 1L;
+        private final transient PublishEiffelArtifactsStep step;
+
+        public Execution(@Nonnull PublishEiffelArtifactsStep step, StepContext context) {
+            super(context);
+            this.step = step;
+        }
+
+        @Override
+        protected Void run() throws Exception {
+            Run run = getContext().get(Run.class);
+            EiffelActivityAction action = run.getAction(EiffelActivityAction.class);
+            EiffelArtifactPublisher artifactPublisher = new EiffelArtifactPublisher(
+                    action.getTriggerEvent(), Util.getRunUri(run), run.getArtifactManager().root());
+
+            try {
+                for (EiffelArtifactToPublishAction savedArtifact : run.getActions(EiffelArtifactToPublishAction.class)) {
+                    publishArtifact(artifactPublisher, savedArtifact.getEvent());
+                }
+            } catch (EmptyArtifactException | EventValidationFailedException | JsonProcessingException
+                    | MissingArtifactException | SchemaUnavailableException e) {
+                throw new AbortException(String.format(
+                        "%s (%s): %s", ERROR_MESSAGE_PREFIX, e.getClass().getSimpleName(), e.getMessage()));
+            }
+            return null;
+        }
+
+        private void publishArtifact(@Nonnull final EiffelArtifactPublisher artifactPublisher,
+                                     @Nonnull final EiffelArtifactCreatedEvent creationEvent) throws Exception {
+            EiffelArtifactPublishedEvent event = artifactPublisher.prepareEvent(creationEvent);
+            JsonNode sentJSON = Util.mustPublishEvent(event);
+            if (sentJSON != null) {
+                getContext().get(TaskListener.class).getLogger().format(
+                        "Successfully sent %s with id %s for artifact with id %s%n",
+                        event.getMeta().getType(), event.getMeta().getId(),
+                        creationEvent.getMeta().getId());
+            }
+        }
+    }
+
+    @Extension
+    public static class Descriptor extends StepDescriptor {
+        @Override
+        public Set<? extends Class<?>> getRequiredContext() {
+            return ImmutableSet.of(Run.class, TaskListener.class);
+        }
+
+        @Override
+        @Nonnull
+        public String getDisplayName() {
+            return "Publishes previously announced Eiffel artifacts";
+        }
+
+        @Override
+        public String getFunctionName() {
+            return "publishEiffelArtifacts";
+        }
+    }
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/config.groovy
@@ -1,0 +1,32 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.CreatePackageURLStep
+
+def f = namespace(lib.FormTagLib)
+
+f.entry(title: "Artifact event filename pattern", field: "artifactEventFiles") {
+    f.textbox()
+}
+

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help-artifactEventFiles.html
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help-artifactEventFiles.html
@@ -1,0 +1,9 @@
+<div>
+    If non-empty, specifies an Ant-style filename pattern that selects one or more files containing
+    <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactCreatedEvent.md">
+        EiffelArtifactCreatedEvent
+    </a> JSON objects (one per line). Each such event will result in an
+    <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactPublishedEvent.md">
+        EiffelArtifactPublishedEvent
+    </a>.
+</div>

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help.html
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help.html
@@ -1,0 +1,25 @@
+<div>
+    <p>
+        Sends an
+        <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactPublishedEvent.md">
+            EiffelArtifactPublishedEvent
+        </a> for each
+        <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactCreatedEvent.md">
+            EiffelArtifactCreatedEvent
+        </a>
+        that has been recorded in the build using a sendEiffelEvent step with
+        the <tt>publishArtifact</tt> argument enabled.
+    </p>
+    <p>
+        This requires that each EiffelArtifactPublishedEvent has at least one file defined in its
+        <tt>data.fileInformation</tt> array and that each relative file path in <tt>data.fileInformation.name</tt>
+        matches a Jenkins artifact in the build. Because of the latter requirement it's normally used after an
+        <a href="https://www.jenkins.io/doc/pipeline/steps/core/#code-archiveartifacts-code-archive-the-artifacts">
+            archiveArtifacts
+        </a> step.
+    </p>
+    <p>
+        The EiffelArtifactPublishedEvent will have two links; one ARTIFACT link to the EiffelArtifactCreatedEvent
+        and one CONTEXT link to the parent build's EiffelActivityTriggeredEvent.
+    </p>
+</div>

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help.html
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep/help.html
@@ -8,7 +8,8 @@
             EiffelArtifactCreatedEvent
         </a>
         that has been recorded in the build using a sendEiffelEvent step with
-        the <tt>publishArtifact</tt> argument enabled.
+        the <tt>publishArtifact</tt> argument enabled. Optionally also EiffelArtifactCreatedEvent events recorded
+        in a file in the workspace.
     </p>
     <p>
         This requires that each EiffelArtifactPublishedEvent has at least one file defined in its

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
@@ -1,0 +1,141 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nonnull;
+import jenkins.util.VirtualFile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Matchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class EiffelArtifactPublisherTest {
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+
+    @Test(expected = EmptyArtifactException.class)
+    public void testPrepareEvent_WithNoFilesInArtC() throws Exception {
+        URI jobURI = new URI("http://jenkins/job/MyJob/");
+        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
+                VirtualFile.forFile(tempDir.getRoot()));
+
+        publisher.prepareEvent(artC);
+    }
+
+    @Test
+    public void testPrepareEvent_HasExpectedLinks() throws Exception {
+        ArtifactFiles files = new ArtifactFiles("filename.zip");
+        URI jobURI = new URI("http://jenkins/job/MyJob/");
+        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        files.addFilesToEvent(artC);
+        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
+                VirtualFile.forFile(tempDir.getRoot()));
+
+        EiffelArtifactPublishedEvent artP = publisher.prepareEvent(artC);
+
+        assertThat(artP, linksTo(actT, EiffelEvent.Link.Type.CONTEXT));
+        assertThat(artP, linksTo(artC, EiffelEvent.Link.Type.ARTIFACT));
+    }
+
+    @Test
+    public void testPrepareEvent_WithFilesMatchingArtC() throws Exception {
+        ArtifactFiles files = new ArtifactFiles("filename.zip", "subdir/filename2.zip");
+        URI jobURI = new URI("http://jenkins/job/MyJob/");
+        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        files.addFilesToEvent(artC);
+        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
+                VirtualFile.forFile(tempDir.getRoot()));
+
+        EiffelArtifactPublishedEvent artP = publisher.prepareEvent(artC);
+
+        assertThat(artP.getData().getLocations(), containsInAnyOrder(files.getLocations(jobURI).toArray()));
+    }
+
+    @Test(expected = MissingArtifactException.class)
+    public void testPrepareEvent_WithMissingFile() throws Exception {
+        ArtifactFiles files = new ArtifactFiles("filename.zip");
+        URI jobURI = new URI("http://jenkins/job/MyJob/");
+        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        // Add an extra artifact file directly to the event. This won't have a physical counterpart in tempDir.
+        artC.getData().getFileInformation().add(
+                new EiffelArtifactCreatedEvent.Data.FileInformation("otherfile.txt"));
+        files.addFilesToEvent(artC);
+        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
+                VirtualFile.forFile(tempDir.getRoot()));
+
+        publisher.prepareEvent(artC);
+    }
+
+    /**
+     * Helper class for creating files in {@link EiffelArtifactPublisherTest#tempDir} and transforming
+     * the collection of filenames in various ways needed by the tests.
+     */
+    private class ArtifactFiles {
+        private List<String> filenames = new ArrayList<>();
+
+        public ArtifactFiles(@Nonnull final String... filenames) throws IOException {
+            for (String filename : filenames) {
+                this.filenames.add(filename);
+                File file = new File(tempDir.getRoot(), filename);
+                file.getParentFile().mkdirs();
+                file.createNewFile();
+            }
+        }
+
+        public void addFilesToEvent(@Nonnull final EiffelArtifactCreatedEvent event) {
+            for (String filename : filenames) {
+                event.getData().getFileInformation().add(new EiffelArtifactCreatedEvent.Data.FileInformation(filename));
+            }
+        }
+
+        public List<EiffelArtifactPublishedEvent.Data.Location> getLocations(@Nonnull final URI baseURI) {
+            List<EiffelArtifactPublishedEvent.Data.Location> result = new ArrayList<>();
+            for (String filename : filenames) {
+                EiffelArtifactPublishedEvent.Data.Location location = new EiffelArtifactPublishedEvent.Data.Location(
+                        EiffelArtifactPublishedEvent.Data.Location.Type.PLAIN, baseURI.resolve("artifact/" + filename));
+                location.setName(filename);
+                result.add(location);
+            }
+            return result;
+        }
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.hamcrest.Matcher;
 
 /**
@@ -53,6 +54,20 @@ public class EventSet {
         for (String message : messages) {
             events.add(mapper.readValue(message, EiffelEvent.class));
         }
+    }
+
+    /**
+     * Finds and returns all events of a particular class. As opposed to {@link #findNext(Class)}
+     * all returned events will be kept in the set.
+     *
+     * @param clazz the class to look for
+     * @return a list of all matching events
+     */
+    public <T> List<T> all(Class<T> clazz) {
+        return events.stream()
+                .filter(clazz::isInstance)
+                .map(clazz::cast)
+                .collect(Collectors.toList());
     }
 
     /**

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
@@ -1,0 +1,90 @@
+/**
+ The MIT License
+
+ Copyright 2021 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelBroadcasterConfig;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EventSet;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Mocks;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
+import hudson.model.Result;
+import hudson.model.Run;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class PublishEiffelArtifactsStepTest {
+    @Rule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
+        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        String pipelineCode = new String(
+                Files.readAllBytes(Paths.get(getClass().getResource(pipelineCodeResourceFile).toURI())),
+                StandardCharsets.UTF_8.name());
+        job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
+        return job;
+    }
+
+    @BeforeClass
+    public static void setUpBeforeClass() throws Exception {
+        new Mocks.RabbitMQConnectionMock();
+    }
+
+    @Before
+    public void setUp() {
+        Mocks.messages.clear();
+        EiffelBroadcasterConfig.getInstance().setEnableBroadcaster(true);
+    }
+
+    @Test
+    public void testSuccessful_PublishesArtifacts() throws Exception {
+        WorkflowJob job = createJob("successful_publish_artifact_step.groovy");
+        jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
+
+        EventSet events = new EventSet(Mocks.messages);
+
+        Run run = job.getBuildByNumber(1);
+        // We have pretty thorough tests of the ArtP contents for a given ArtC so here it's enough to
+        // verify that we get the correct number of events and that the filenames in the events are what
+        // we expect (so we're not getting two copies of the same event).
+        List<String> allLocationNames = events.all(EiffelArtifactPublishedEvent.class).stream()
+                .flatMap(event -> event.getData().getLocations().stream())
+                .map(EiffelArtifactPublishedEvent.Data.Location::getName)
+                .collect(Collectors.toList());
+        assertThat(allLocationNames, containsInAnyOrder("a.txt", "b.txt"));
+    }
+}

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/failed_publish_artifact_step_from_file_bad_type.groovy
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/failed_publish_artifact_step_from_file_bad_type.groovy
@@ -1,0 +1,15 @@
+node {
+    def event = [
+        'meta': [
+            'type': 'EiffelCompositionDefinedEvent',
+            'version': '3.0.0',
+        ],
+        'data': [
+            'name': 'foo',
+        ],
+    ]
+
+    writeJSON file: 'events.json', json: event
+    publishEiffelArtifacts artifactEventFiles: 'events.json'
+}
+

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step.groovy
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step.groovy
@@ -1,0 +1,42 @@
+node {
+    def events = [
+        [
+            'meta': [
+                'type': 'EiffelArtifactCreatedEvent',
+                'version': '3.0.0',
+            ],
+            'data': [
+                'identity': 'pkg:generic/foo',
+                'fileInformation': [
+                    [
+                        'name': 'a.txt',
+                    ],
+                ],
+            ],
+        ],
+        [
+            'meta': [
+                'type': 'EiffelArtifactCreatedEvent',
+                'version': '3.0.0',
+            ],
+            'data': [
+                'identity': 'pkg:generic/foo',
+                'fileInformation': [
+                    [
+                        'name': 'b.txt',
+                    ],
+                ],
+            ],
+        ],
+    ]
+    events.each {
+        sendEiffelEvent event: it, publishArtifact: true
+        it.data.fileInformation.each {
+            writeFile file: it.name, text: ''
+        }
+    }
+
+    archiveArtifacts artifacts: '**'
+    publishEiffelArtifacts()
+}
+

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step_from_file.groovy
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step_from_file.groovy
@@ -1,0 +1,49 @@
+import groovy.json.JsonOutput
+
+node {
+    def events = [
+        [
+            'meta': [
+                'type': 'EiffelArtifactCreatedEvent',
+                'version': '3.0.0',
+            ],
+            'data': [
+                'identity': 'pkg:generic/foo',
+                'fileInformation': [
+                    [
+                        'name': 'a.txt',
+                    ],
+                    [
+                        'name': 'b.txt',
+                    ],
+                ],
+            ],
+        ],
+        [
+            'meta': [
+                'type': 'EiffelArtifactCreatedEvent',
+                'version': '3.0.0',
+            ],
+            'data': [
+                'identity': 'pkg:generic/foo',
+                'fileInformation': [
+                    [
+                        'name': 'c.txt',
+                    ],
+                    [
+                        'name': 'd.txt',
+                    ],
+                ],
+            ],
+        ],
+    ]
+    events.collect { it.data.fileInformation }.flatten()*.name.each {
+        writeFile file: it, text: ''
+    }
+
+    archiveArtifacts artifacts: '*.txt'
+    writeFile file: 'events.json',
+        text: events.collect { JsonOutput.toJson(it) }.join('\n')
+    publishEiffelArtifacts artifactEventFiles: 'events.json'
+}
+

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_send_event_step_with_artifacts.groovy
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_send_event_step_with_artifacts.groovy
@@ -1,0 +1,13 @@
+node {
+    def event = [
+            'meta': [
+                    'type': 'EiffelArtifactCreatedEvent',
+                    'version': '3.0.0',
+            ],
+            'data': [
+                    'identity': 'pkg:generic/foo',
+            ],
+    ]
+    sendEiffelEvent event: event, publishArtifact: true
+    sendEiffelEvent event: event, publishArtifact: true
+}


### PR DESCRIPTION
If ArtC and ArtP are sent together during the build, consumers are susceptible to races since the Jenkins artifact URIs in the ArtP might not be available (since artifact archival is usually done at the very end of the build).

The new publishArtifact argument to the sendEiffelEvent step records the ArtC in the Run and a subsequent call to publishEiffelArtifact when the Jenkins artifacts have been made available (typically by using the archiveArtifacts step) will construct and send ArtP event(s) based on the ArtC events.

Sometimes the artifact creations are buried deep inside build scripts and calling the sendEiffelEvent pipeline step with publishArtifact set isn't possible.
    
To support that use case we add an artifactEventFiles argument to the publishEiffelArtifacts step. It contains an Ant-style glob expression that selects workspace files from which to read JSON representations of ArtC events. Those events will be treated exactly the same as events recorded in the Run via sendEiffelEvent.

Fixes #46. I strongly recommend reviewing the commits separately.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
