### PR TITLE
Fix bug that broke configuration serialization

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -91,7 +91,7 @@ public final class EiffelBroadcasterConfig extends Plugin implements Describable
     /* A list of strings representing categories to include in the ActTs. */
     private final List<String> activityCategories = new ArrayList<>();
 
-    private final EventValidator eventValidator = new EventValidator();
+    private transient final EventValidator eventValidator = new EventValidator();
 
     /**
      * Creates an instance with specified parameters.


### PR DESCRIPTION
Attempting to serialize EiffelBroadcasterConfig#eventValidator will blow up since one of the Jackson classes isn't deemed safe for serialization, and that's totally fine. The EventValidator instance wasn't meant to be serialized anyway.

This has been broken since commit e8171f6 but wasn't discovered since no tests attempt to save the configuration to disk (maybe they should?) and no manual testing prompted a configuration save.

Perhaps the event validator should be its own singleton instead of piggy-packing on the EiffelBroadcasterConfig singleton. Let's think about that when we revamp EiffelBroadcasterConfig to not extend the deprecated Plugin class.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
