### PR TITLE
Always add default values for missing params given in $BUILD_URL/eiffel/build request

### DIFF
--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
@@ -36,7 +36,6 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
-import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
@@ -52,6 +51,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import static com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Matchers.*;
 import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
 import static javax.servlet.http.HttpServletResponse.SC_CREATED;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -133,11 +133,7 @@ public class BuildWithEiffelLinksActionTest {
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
-        ParametersAction paramAction = build.getAction(ParametersAction.class);
-        assertThat(paramAction, is(notNullValue()));
-        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
-        assertThat(actualParam, is(notNullValue()));
-        assertThat(actualParam.getValue(), is("overridden value"));
+        assertThat(build, hasBuildParameter(stringParam.getName(), "overridden value"));
     }
 
     @Test
@@ -162,11 +158,7 @@ public class BuildWithEiffelLinksActionTest {
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
-        ParametersAction paramAction = build.getAction(ParametersAction.class);
-        assertThat(paramAction, is(notNullValue()));
-        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
-        assertThat(actualParam, is(notNullValue()));
-        assertThat(actualParam.getValue(), is("overridden value"));
+        assertThat(build, hasBuildParameter(stringParam.getName(), "overridden value"));
     }
 
     @Test
@@ -247,11 +239,7 @@ public class BuildWithEiffelLinksActionTest {
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
-        ParametersAction paramAction = build.getAction(ParametersAction.class);
-        assertThat(paramAction, is(notNullValue()));
-        ParameterValue actualParam = paramAction.getParameter(stringParam.getName());
-        assertThat(actualParam, is(notNullValue()));
-        assertThat(actualParam.getValue(), is("value"));
+        assertThat(build, hasBuildParameter(stringParam.getName(), "value"));
     }
 
     /**

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Matchers.java
@@ -26,12 +26,15 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersAction;
+import hudson.model.Run;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 /**
- * A collection of Hamcrest {@link Matcher} functions that inspect the state of Eiffel events.
+ * A collection of Hamcrest {@link Matcher} functions that e.g. inspect the state of Eiffel events.
  */
 public class Matchers {
     /**
@@ -65,6 +68,35 @@ public class Matchers {
     public static Matcher<EiffelActivityTriggeredEvent> hasTrigger(
             EiffelActivityTriggeredEvent.Data.Trigger.Type type) {
         return hasTrigger(type, "");
+    }
+
+    /**
+     * Returns a matcher that checks whether the subject {@link Run} has a parameter
+     * with the given name and value.
+     *
+     * @param name the expected name of the parameter
+     * @param value the expected value of the parameter
+     */
+    public static Matcher<Run> hasBuildParameter(String name, Object value) {
+        return new TypeSafeMatcher<Run>() {
+            @Override
+            protected boolean matchesSafely(Run run) {
+                ParametersAction paramAction = run.getAction(ParametersAction.class);
+                if (paramAction == null) {
+                    return false;
+                }
+                ParameterValue actualParam = paramAction.getParameter(name);
+                if (actualParam == null) {
+                    return false;
+                }
+                return value.equals(actualParam.getValue());
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendText(String.format("run having a %s parameter with the value '%s'", name, value));
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
The logic in BuildWithEiffelLinksAction#getParametersAction was deeply flawed when the build request didn't provide values for all parameters defined for the job; default values were only included for all parameters if the build request didn't contain _any parameters at all_ but _never_ otherwise. We now make sure to always add default values for parameters that weren't present in the request.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
