### PR TITLE
README: Link to Eiffel Summit slides and video

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ The plugin can be extended with more events and or more data but the required da
 A detailed list of event representations can be found in the table below.
 
 Read more about the Eiffel protocol at https://eiffel-community.github.io/.
+The plugin and its features were presented at the 2021 Eiffel Summit;
+the [presentation slides](https://github.com/eiffel-community/community/blob/master/presentations/eiffel_summit_2021.1/The%20eiffel-broadcaster%20Jenkins%20plugin.pdf)
+and a [video](https://youtu.be/fRCq9VosRJA) are available.
 
 ## Jenkins events represented in Eiffel
 


### PR DESCRIPTION
Now that the slides and video from the [Eiffel Summit](https://eiffel-community.github.io/summit.html) are available online let's link to them in the README to give readers and option to reading the docs to get an impression of the plugin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
