### PR TITLE
Populate meta.source for events sent via the sendEiffelEvent pipeline step

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -99,10 +99,18 @@ public class JenkinsSourceProvider implements SourceProvider {
     /** {@inheritDoc} */
     @Override
     public void populateSource(@Nonnull EiffelEvent.Meta.Source source) {
-        source.setHost(getHost());
-        source.setName(name);
+        // Most source values can be set by the input event so don't overwrite existing values,
+        // except for the serializer since it's always this plugin that does the serialization.
+        if (source.getHost() == null) {
+            source.setHost(getHost());
+        }
+        if (source.getName() == null) {
+            source.setName(name);
+        }
         source.setSerializer(serializer);
-        source.setUri(uri);
+        if (source.getUri() == null) {
+            source.setUri(uri);
+        }
     }
 
     /**

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
@@ -25,6 +25,8 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.packageurl.PackageURL;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -55,5 +57,15 @@ public class JenkinsSourceProviderTest {
         assertThat(purl.getName(), is("eiffel-broadcaster"));
         // Not testing meta.source.uri since it isn't available during tests.
         // Not testing meta.source.host to avoid test flakiness.
+    }
+
+    @Test
+    public void testSourceNameIsNotOverwritten() throws Exception {
+        EiffelEvent event = new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelActivityTriggeredEvent.json"), EiffelEvent.class);
+        // We get the meta.source.name value from the JSON file
+        assertThat(event.getMeta().getSource().getName(), is("Custom meta.source.name"));
+        // We get the meta.source.serializer value from JenkinsSourceProvider
+        assertThat(event.getMeta().getSource().getSerializer(), is(notNullValue()));
     }
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
@@ -54,4 +54,40 @@ public class EiffelEventTest {
         new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent_without_meta.json"), EiffelEvent.class);
     }
+
+    @Test
+    public void testSourceProvider_WithDirectConstruction() throws IOException {
+        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
+        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
+    }
+
+    @Test
+    public void testSourceProvider_FromJsonToConcreteClass() throws IOException {
+        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
+        EiffelEvent event = new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelActivityTriggeredEvent.json"), EiffelEvent.class);
+        assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
+    }
+
+    @Test
+    public void testSourceProvider_FromJsonToGenericClass() throws IOException {
+        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
+        EiffelEvent event = new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
+        // First make sure we actually get a GenericEiffelEvent object. If we introduce a concrete
+        // class for EiffelCompositionDefinedEvent this testcase must be updated to not follow
+        // the same code path as testSourceProvider_FromJsonToConcreteClass.
+        assertThat(event, instanceOf(GenericEiffelEvent.class));
+        assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
+    }
+
+    class DummyDomainIdProvider implements SourceProvider {
+        static final String DOMAIN_ID = "dummy";
+
+        @Override
+        public void populateSource(EiffelEvent.Meta.Source source) {
+            source.setDomainId(DOMAIN_ID);
+        }
+    }
 }

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityTriggeredEvent.json
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityTriggeredEvent.json
@@ -1,0 +1,21 @@
+{
+  "meta": {
+    "type": "EiffelActivityTriggeredEvent",
+    "version": "4.1.0",
+    "time": 1234567890,
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
+    "tags": ["foo", "bar"],
+    "source": {
+      "name": "Custom meta.source.name"
+    }
+  },
+  "data": {
+    "name": "Activity name",
+    "triggers": [
+      {
+        "type": "MANUAL"
+      }
+    ]
+  },
+  "links": []
+}

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.json
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.json
@@ -1,0 +1,17 @@
+{
+  "meta": {
+    "type": "EiffelActivityTriggeredEvent",
+    "version": "4.1.0",
+    "time": 1234567890,
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0"
+  },
+  "data": {
+    "name": "Activity name",
+    "triggers": [
+      {
+        "type": "MANUAL"
+      }
+    ]
+  },
+  "links": []
+}


### PR DESCRIPTION
Previously the meta.source fields were only populated when an event class was instantiated directly, i.e. if the event was created by code in the plugin. Event objects created by the sendEiffelEvent pipeline step never asked the configured SourceProvider to populate meta.source.

The reason for this bug is that it was the EiffelEvent class that called the SourceProvider, but this was only done in the constructor. When deserializing JSON into an object the EiffelEvent#meta attribute is overwritten by Jackson after the event object is initialized, hence overwriting the SourceProvider-created value with the (possibly empty) EiffelEvent.Meta object created by Jackson.

We addresss this by changing the custom deserializer to ask EiffelEvent to populate meta.source after an event object has been created. This also required changing JenkinsSourceProvider to not overwrite already set meta.source values.

Fixes #60.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
