### PR TITLE
Add missing toString() methods

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
@@ -249,6 +249,16 @@ public class EiffelActivityFinishedEvent extends EiffelEvent {
             public int hashCode() {
                 return Objects.hash(mediaType, name, tags, uri);
             }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("mediaType", mediaType)
+                        .append("name", name)
+                        .append("tags", tags)
+                        .append("uri", uri)
+                        .toString();
+            }
         }
     }
 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
@@ -185,6 +185,16 @@ public class EiffelActivityStartedEvent extends EiffelEvent {
             public int hashCode() {
                 return Objects.hash(mediaType, name, tags, uri);
             }
+
+            @Override
+            public String toString() {
+                return new ToStringBuilder(this)
+                        .append("mediaType", mediaType)
+                        .append("name", name)
+                        .append("tags", tags)
+                        .append("uri", uri)
+                        .toString();
+            }
         }
     }
 }


### PR DESCRIPTION
The toString() method had inadvertently been left out from EiffelActivityStartedEvent.Data.LiveLogs and EiffelActivityFinishedEvent.Data.PersistentLogs.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
