### PR TITLE
Add JCasC support and modernize to extend from GlobalConfiguration instead of Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <commons.lang3.version>3.11</commons.lang3.version>
         <commons.validator.version>1.7</commons.validator.version>
         <jackson2-api.version>2.11.1</jackson2-api.version>
-        <jenkins-test-harness.version>2.49</jenkins-test-harness.version>
+        <jenkins-test-harness.version>2.72</jenkins-test-harness.version>
         <jmockit.version>1.41</jmockit.version>
         <json-schema-validator.version>1.0.43</json-schema-validator.version>
         <packageurl.version>1.2.0</packageurl.version>
@@ -102,6 +102,16 @@
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins</groupId>
+            <artifactId>configuration-as-code</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.configuration-as-code</groupId>
+            <artifactId>test-harness</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -47,7 +47,7 @@ import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.UrlValidator;
 import org.jenkinsci.Symbol;
-import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.interceptor.RequirePOST;
@@ -73,7 +73,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
     private static final String CONFIG_XML = "eiffel-broadcaster.xml";
 
     /* The status whether the plugin is enabled */
-    private boolean enableBroadcaster;
+    private boolean enableBroadcaster = false;
 
     /* The MQ server URI */
     private String serverUri;
@@ -91,7 +91,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      */
     private String routingKey;
     /* Messages delivered to durable queues will be logged to disk if persistent delivery is set. */
-    private boolean persistentDelivery;
+    private boolean persistentDelivery = true;
     /* Application id that can be read by the consumer (optional). */
     private String appId;
     /* A list of strings representing categories to include in the ActTs. */
@@ -101,44 +101,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
 
     private transient final EventValidator eventValidator = new EventValidator();
 
-    /**
-     * Creates an instance with specified parameters.
-     *
-     * @param enableBroadcaster  if this plugin is enabled
-     * @param serverUri          the server uri
-     * @param userName           the user name
-     * @param userPassword       the user password
-     * @param exchangeName       the name of the exchange
-     * @param virtualHost        the name of the virtual host
-     * @param routingKey         the routing key
-     * @param persistentDelivery if using persistent delivery mode
-     * @param appId              the application id
-     */
-    @DataBoundConstructor
-    public EiffelBroadcasterConfig(boolean enableBroadcaster, String serverUri, String userName, Secret userPassword,
-                            String exchangeName, String virtualHost, String routingKey, boolean persistentDelivery,
-                            String appId, String activityCategories, HostnameSource hostnameSource) {
-        this.enableBroadcaster = enableBroadcaster;
-        this.serverUri = serverUri;
-        this.userName = userName;
-        this.userPassword = userPassword;
-        this.exchangeName = exchangeName;
-        this.virtualHost = virtualHost;
-        this.routingKey = routingKey;
-        this.persistentDelivery = persistentDelivery;
-        this.appId = appId;
-        this.activityCategories.addAll(Util.getLinesInString(activityCategories));
-        this.hostnameSource = hostnameSource;
-        super.load();
-        EiffelEvent.setSourceProvider(new JenkinsSourceProvider());
-    }
-
-    /**
-     * Load configuration on invoke.
-     */
     public EiffelBroadcasterConfig() {
-        this.enableBroadcaster = false; // default value
-        this.persistentDelivery = true; // default value
         super.load();
         EiffelEvent.setSourceProvider(new JenkinsSourceProvider());
     }
@@ -175,6 +138,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param enableBroadcaster true if this plugin is enabled.
      */
+    @DataBoundSetter
     public void setEnableBroadcaster(boolean enableBroadcaster) {
         this.enableBroadcaster = enableBroadcaster;
     }
@@ -193,6 +157,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param serverUri the URI.
      */
+    @DataBoundSetter
     public void setServerUri(final String serverUri) {
         this.serverUri = StringUtils.strip(StringUtils.stripToNull(serverUri), "/");
     }
@@ -211,6 +176,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param userName the user name.
      */
+    @DataBoundSetter
     public void setUserName(String userName) {
         this.userName = userName;
     }
@@ -229,6 +195,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param userPassword the user password.
      */
+    @DataBoundSetter
     public void setUserPassword(Secret userPassword) {
         this.userPassword = userPassword;
     }
@@ -254,6 +221,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param exchangeName the exchange name.
      */
+    @DataBoundSetter
     public void setExchangeName(String exchangeName) {
         this.exchangeName = exchangeName;
     }
@@ -272,6 +240,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param virtualHost the exchange name.
      */
+    @DataBoundSetter
     public void setVirtualHost(String virtualHost) {
         this.virtualHost = virtualHost;
     }
@@ -290,6 +259,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param routingKey the routing key.
      */
+    @DataBoundSetter
     public void setRoutingKey(String routingKey) {
         this.routingKey = routingKey;
     }
@@ -309,6 +279,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param pd if persistentDelivery is to be used.
      */
+    @DataBoundSetter
     public void setPersistentDelivery(boolean pd) {
         this.persistentDelivery = pd;
     }
@@ -327,6 +298,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
      *
      * @param appId Application id to use
      */
+    @DataBoundSetter
     public void setAppId(String appId) {
         this.appId = appId;
     }
@@ -342,6 +314,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
     }
 
     /** Sets the list of categories to attach to the activities. */
+    @DataBoundSetter
     public void setActivityCategories(String activityCategories) {
         this.activityCategories.clear();
         this.activityCategories.addAll(Util.getLinesInString(activityCategories));
@@ -353,6 +326,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
     }
 
     /** Sets the hostname source. */
+    @DataBoundSetter
     public void setHostnameSource(HostnameSource hostnameSource) {
         this.hostnameSource = hostnameSource;
     }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
@@ -51,7 +51,7 @@ public class ItemListenerImpl extends ItemListener {
     public final void onLoaded() {
         logger.info("All jobs have been loaded.");
         EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        if (config != null && config.isBroadcasterEnabled()) {
+        if (config != null && config.getEnableBroadcaster()) {
             MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),
                     config.getServerUri(), config.getVirtualHost());
             // initialize EiffelJobTable singleton.

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -29,7 +29,6 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SourceProvider;
 import com.github.packageurl.MalformedPackageURLException;
 import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
-import hudson.Plugin;
 import hudson.PluginWrapper;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
@@ -42,6 +41,7 @@ import java.time.Instant;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
+import org.jenkinsci.Symbol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,9 +71,9 @@ public class JenkinsSourceProvider implements SourceProvider {
     public JenkinsSourceProvider() {
         Jenkins jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
-            Plugin plugin = jenkins.getPlugin(EiffelBroadcasterConfig.class);
-            if (plugin != null) {
-                PluginWrapper pluginWrapper = plugin.getWrapper();
+            String pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
+            PluginWrapper pluginWrapper = jenkins.getPluginManager().getPlugin(pluginShortName);
+            if (pluginWrapper != null) {
                 name = pluginWrapper.getDisplayName();
 
                 if (pluginWrapper.getUrl() != null) {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -125,7 +125,7 @@ public final class Util {
     public static JsonNode mustPublishEvent(String eventName, String eventVersion, @Nonnull final JsonNode eventJson)
             throws EventValidationFailedException, JsonProcessingException, SchemaUnavailableException {
         EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        if (config == null || !config.isBroadcasterEnabled()) {
+        if (config == null || !config.getEnableBroadcaster()) {
             return null;
         }
         AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
@@ -152,7 +152,7 @@ public final class Util {
     public static JsonNode mustPublishEvent(@Nonnull final EiffelEvent event)
             throws EventValidationFailedException, JsonProcessingException, SchemaUnavailableException {
         EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        if (config == null || !config.isBroadcasterEnabled()) {
+        if (config == null || !config.getEnableBroadcaster()) {
             return null;
         }
         JsonNode eventJson = new ObjectMapper().valueToTree(event);

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
@@ -29,38 +29,38 @@ def l = "/plugin/eiffel-broadcaster/"
 f.section(title: "Eiffel Broadcaster Plugin") {
 
     f.entry(title: "Enable Eiffel Broadcaster plugin", help: l+"help-enable-broadcaster.html") {
-        f.checkbox(field: "enableBroadcaster", checked: my.enableBroadcaster)
+        f.checkbox(field: "enableBroadcaster", checked: instance.enableBroadcaster)
     }
     f.entry(title: "MQ URI", field: "serverUri", help: l+"help-amqp-uri.html") {
-        f.textbox("value":my.serverUri)
+        f.textbox("value":instance.serverUri)
     }
     f.entry(title: "User name", field: "userName", help: l+"help-user-name.html") {
-        f.textbox("value":my.userName)
+        f.textbox("value":instance.userName)
     }
     f.entry(title: "Password", field: "userPassword", help: l+"help-user-password.html") {
-        f.password("value":my.userPassword)
+        f.password("value":instance.userPassword)
     }
-    descriptor = my.descriptor
+    descriptor = instance.descriptor
     f.validateButton(title: "Test Connection", progress: "Trying to connect...", method: "testConnection",
             with: "serverUri,userName,userPassword")
 
     f.entry(title: "Exchange Name", field: "exchangeName", help: l+"help-exchange-name.html") {
-        f.textbox("value":my.exchangeName)
+        f.textbox("value":instance.exchangeName)
     }
     f.entry(title: "Virtual host", field: "virtualHost", help: l+"help-virtual-host.html") {
-        f.textbox("value":my.virtualHost)
+        f.textbox("value":instance.virtualHost)
     }
     f.entry(title: "Routing Key", field: "routingKey", help: l+"help-routing-key.html") {
-        f.textbox("value":my.routingKey)
+        f.textbox("value":instance.routingKey)
     }
     f.entry(title: "Application Id", field: "appId", help: l+"help-application-id.html") {
-        f.textbox("value":my.appId)
+        f.textbox("value":instance.appId)
     }
     f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
-        f.checkbox(field: "persistentDelivery", checked: my.persistentDelivery)
+        f.checkbox(field: "persistentDelivery", checked: instance.persistentDelivery)
     }
     f.entry(title: "Activity Categories", field: "activityCategories", help: l+"help-activity-categories.html") {
-        f.textarea(value: my.activityCategories)
+        f.textarea(value: instance.activityCategories)
     }
     f.entry(title: "Hostname source", field: "hostnameSource", help: l+"help-hostname-source.html") {
         f.enum {

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
@@ -59,7 +59,7 @@ import static org.hamcrest.Matchers.*;
 
 public class BuildWithEiffelLinksActionTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     public WebResponse postBuildRequest(final Job job, final String jsonPayload) throws IOException {
         JenkinsRule.WebClient wc = jenkins.createWebClient();

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConfigurationAsCodeTest.java
@@ -1,0 +1,73 @@
+/**
+ The MIT License
+
+ Copyright 2022 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.ConfiguratorRegistry;
+import io.jenkins.plugins.casc.misc.ConfiguredWithCode;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+import io.jenkins.plugins.casc.model.CNode;
+import org.jenkinsci.Symbol;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.jenkins.plugins.casc.misc.Util.getUnclassifiedRoot;
+import static io.jenkins.plugins.casc.misc.Util.toStringFromYamlFile;
+import static io.jenkins.plugins.casc.misc.Util.toYamlString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class ConfigurationAsCodeTest {
+    // {@link JenkinsConfiguredWithCodeRule} requires that the formal type of the rule attribute
+    // is JenkinsConfiguredWithCodeRule.
+    @Rule
+    public JenkinsConfiguredWithCodeRule jenkins = new RestoreSourceProviderJenkinsConfiguredWithCodeRule();
+
+    @Test
+    @ConfiguredWithCode("jcasc-input.yml")
+    public void testSupportsConfigurationAsCode() throws Exception {
+        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        assertThat(config.getAppId(), is("random-appid"));
+        assertThat(config.getEnableBroadcaster(), is(true));
+        assertThat(config.getExchangeName(), is("eiffel-exchange"));
+        assertThat(config.getHostnameSource(), is(HostnameSource.CONFIGURED_URL));
+        assertThat(config.getPersistentDelivery(), is(false));
+        assertThat(config.getRoutingKey(), is("random-routing-key"));
+        assertThat(config.getServerUri(), is("amqp://rabbitmq.example.com"));
+        assertThat(config.getUserName(), is("johndoe"));
+        assertThat(config.getVirtualHost(), is("/"));
+    }
+
+    @Test
+    @ConfiguredWithCode("jcasc-input.yml")
+    public void testSupportsConfigurationExport() throws Exception {
+        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
+        String pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
+        CNode pluginNode = getUnclassifiedRoot(context).get(pluginShortName);
+        String sanitizedYAML = toYamlString(pluginNode).replaceFirst("(?m)^userPassword: .*(?:\\r?\\n)?", "");
+        assertThat(sanitizedYAML, is(toStringFromYamlFile(this, "jcasc-expected-output.yml")));
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
@@ -34,14 +34,13 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class EiffelEnvironmentContributorTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -45,7 +45,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,7 +57,7 @@ import static org.hamcrest.Matchers.*;
  */
 public class EmittedEventsTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
@@ -31,14 +31,13 @@ import com.github.packageurl.PackageURL;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class JenkinsSourceProviderTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     @BeforeClass
     public static void setUpBeforeClass() throws Exception {

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RestoreSourceProviderJenkinsConfiguredWithCodeRule.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RestoreSourceProviderJenkinsConfiguredWithCodeRule.java
@@ -1,0 +1,47 @@
+/**
+ The MIT License
+
+ Copyright 2022 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import io.jenkins.plugins.casc.misc.JenkinsConfiguredWithCodeRule;
+
+/**
+ * Extends {@link JenkinsConfiguredWithCodeRule} to also clear the
+ * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SourceProvider}
+ * stored in a static attribute in {@link EiffelEvent}. It gets set to an instance
+ * of {@link JenkinsSourceProvider} when the plugin is run in a Jenkins instance,
+ * but that class requires a Jenkins instance to be available so subsequently run
+ * tests will fail unless we clear the source provider.
+ *
+ * We should refactor the code to not use a static attribute like this, but until
+ * that's done this'll have to do.
+ */
+public class RestoreSourceProviderJenkinsConfiguredWithCodeRule extends JenkinsConfiguredWithCodeRule {
+    @Override
+    public void after() throws Exception {
+        super.after();
+        EiffelEvent.setSourceProvider(null);
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RestoreSourceProviderJenkinsRule.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RestoreSourceProviderJenkinsRule.java
@@ -1,0 +1,47 @@
+/**
+ The MIT License
+
+ Copyright 2022 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Extends {@link JenkinsRule} to also clear the
+ * {@link com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SourceProvider}
+ * stored in a static attribute in {@link EiffelEvent}. It gets set to an instance
+ * of {@link JenkinsSourceProvider} when the plugin is run in a Jenkins instance,
+ * but that class requires a Jenkins instance to be available so subsequently run
+ * tests will fail unless we clear the source provider.
+ *
+ * We should refactor the code to not use a static attribute like this, but until
+ * that's done this'll have to do.
+ */
+public class RestoreSourceProviderJenkinsRule extends JenkinsRule {
+    @Override
+    public void after() throws Exception {
+        super.after();
+        EiffelEvent.setSourceProvider(null);
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStepTest.java
@@ -24,16 +24,16 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline;
 
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.RestoreSourceProviderJenkinsRule;
 import hudson.model.Result;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 public class CreatePackageURLStepTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     private WorkflowJob createJob(String purlCreationSnippet) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
@@ -27,6 +27,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelBroadcasterConfig;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EventSet;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Mocks;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.RestoreSourceProviderJenkinsRule;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -41,14 +42,13 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 
 public class PublishEiffelArtifactsStepTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStepTest.java
@@ -28,6 +28,7 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelArtifactToPublish
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelBroadcasterConfig;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EventSet;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Mocks;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.RestoreSourceProviderJenkinsRule;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
@@ -46,7 +47,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Matchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -54,7 +54,7 @@ import static org.hamcrest.Matchers.*;
 
 public class SendEiffelEventStepTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
+    public RestoreSourceProviderJenkinsRule jenkins = new RestoreSourceProviderJenkinsRule();
 
     private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
         WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-expected-output.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-expected-output.yml
@@ -1,0 +1,9 @@
+appId: "random-appid"
+enableBroadcaster: true
+exchangeName: "eiffel-exchange"
+hostnameSource: CONFIGURED_URL
+persistentDelivery: false
+routingKey: "random-routing-key"
+serverUri: "amqp://rabbitmq.example.com"
+userName: "johndoe"
+virtualHost: "/"

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input.yml
@@ -1,0 +1,12 @@
+unclassified:
+  eiffel-broadcaster:
+    appId: "random-appid"
+    enableBroadcaster: true
+    exchangeName: "eiffel-exchange"
+    hostnameSource: CONFIGURED_URL
+    persistentDelivery: false
+    routingKey: "random-routing-key"
+    serverUri: "amqp://rabbitmq.example.com"
+    userName: "johndoe"
+    userPassword: "{AQAAABAAAAAQamrmPWJHqDjtHxMg0DLrGcCR/HrxsVE6BbBGft31t5g=}"
+    virtualHost: "/"


### PR DESCRIPTION
As a cleanup we convert EiffelBroadcasterConfig from extending the deprecated Plugin class to GlobalConfiguration and make the few adjustments required by that change, including:

- Using a different way of obtaining the plugin's Plugin or PluginWrapper instances since Jenkins#getPlugin only works for plugins that extend Plugin.
- Renaming the getter for EiffelBroadcasterConfig#enableBroadcaster so JCasC can find it.

Another complication of the switch from Plugin to GlobalConfiguration was that the assignment to the static EiffelEvent#sourceProvider attribute for some reason wasn't reset as it used to be. After a test that used JenkinsRule was run the attribute still pointed to a JenkinsSourceProvider instance that required a Jenkins instance to be present. I'm not sure exactly what happens, but introducing JenkinsRule subclasses that clear out EiffelEvent#sourceProvider after each testcase fixes the problem.

The proper fix would be to not use static attributes like this, but absent an injection framework like Guice it's not immediately obvious how to do this (at least not without adding too many dependencies to the rest of the plugin in EiffelEvent and its subclasses).

Note that there are two commits in this PR. You'll probably want to review them one by one.

Fixes #58.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
