### PR TITLE
Fix result translate to null bug in Util.java

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -204,7 +204,7 @@ public final class Util {
     public static EiffelActivityFinishedEvent.Data.Outcome.Conclusion translateStatus(String status) {
         EiffelActivityFinishedEvent.Data.Outcome.Conclusion statusTranslated;
         if (STATUS_TRANSLATION.get(status) == null) {
-            statusTranslated = STATUS_TRANSLATION.get("inconclusive");
+            statusTranslated = STATUS_TRANSLATION.get("INCONCLUSIVE");
         } else {
             statusTranslated = STATUS_TRANSLATION.get(status);
         }


### PR DESCRIPTION
This should fix bug discussed in issue #4 where conclusion set to `null` when build state not recognized by the translation table due to incorrect key.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
