### PR TITLE
Support events from the Arica edition of the protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The plugin conforms to the
 of the Eiffel protocol for the events it emits. Users of the provided
 sendEiffelEvent pipeline step may choose to emit events from any Eiffel
 edition up to and including the
-[Lyon edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-lyon).
+[Arica edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-arica).
 See the documentation of each event for details of the corresponding event version used.
 
 ## Accessing emitted Eiffel events in builds
@@ -192,7 +192,7 @@ This step returns immediately as soon as the event has been validated and put
 in the internal outbound queue. The actual delivery of the event to the broker
 might not have happened at the time of the return. The validation supports all
 events and event versions up to and including the
-[Lyon edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-lyon).
+[Arica edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-arica).
 
 ## API
 The plugin will do its best to populate the emitted

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
@@ -26,6 +26,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.ArrayList;
@@ -191,6 +192,8 @@ public class EiffelArtifactCreatedEvent extends EiffelEvent {
             @JsonInclude(JsonInclude.Include.ALWAYS)
             private String name;
 
+            private IntegrityProtection integrityProtection;
+
             private List<String> tags = new ArrayList<>();
 
             public FileInformation(@JsonProperty("name") String name) {
@@ -205,6 +208,14 @@ public class EiffelArtifactCreatedEvent extends EiffelEvent {
                 this.name = name;
             }
 
+            public IntegrityProtection getIntegrityProtection() {
+                return integrityProtection;
+            }
+
+            public void setIntegrityProtection(IntegrityProtection integrityProtection) {
+                this.integrityProtection = integrityProtection;
+            }
+
             public List<String> getTags() {
                 return tags;
             }
@@ -214,20 +225,94 @@ public class EiffelArtifactCreatedEvent extends EiffelEvent {
                 if (this == o) return true;
                 if (o == null || getClass() != o.getClass()) return false;
                 FileInformation that = (FileInformation) o;
-                return name.equals(that.name) && tags.equals(that.tags);
+                return name.equals(that.name) &&
+                        Objects.equals(integrityProtection, that.integrityProtection) &&
+                        tags.equals(that.tags);
             }
 
             @Override
             public int hashCode() {
-                return Objects.hash(name, tags);
+                return Objects.hash(name, integrityProtection, tags);
             }
 
             @Override
             public String toString() {
                 return new ToStringBuilder(this)
                         .append("name", name)
+                        .append("integrityProtection", integrityProtection)
                         .append("tags", tags)
                         .toString();
+            }
+
+            public static class IntegrityProtection {
+                @JsonInclude(JsonInclude.Include.ALWAYS)
+                private Alg alg;
+
+                @JsonInclude(JsonInclude.Include.ALWAYS)
+                private String digest;
+
+                public IntegrityProtection(@JsonProperty("alg") Alg alg, @JsonProperty("digest") String digest) {
+                    this.alg = alg;
+                    this.digest = digest;
+                }
+
+                public Alg getAlg() {
+                    return alg;
+                }
+
+                public void setAlg(Alg alg) {
+                    this.alg = alg;
+                }
+
+                public String getDigest() {
+                    return digest;
+                }
+
+                public void setDigest(String digest) {
+                    this.digest = digest;
+                }
+
+                @Override
+                public boolean equals(Object o) {
+                    if (this == o) return true;
+                    if (o == null || getClass() != o.getClass()) return false;
+                    IntegrityProtection that = (IntegrityProtection) o;
+                    return alg == that.alg && digest.equals(that.digest);
+                }
+
+                @Override
+                public int hashCode() {
+                    return Objects.hash(alg, digest);
+                }
+
+                @Override
+                public String toString() {
+                    return new ToStringBuilder(this)
+                            .append("alg", alg)
+                            .append("digest", digest)
+                            .toString();
+                }
+
+                public enum Alg {
+                    SHA224("SHA-224"),
+                    SHA256("SHA-256"),
+                    SHA384("SHA-384"),
+                    SHA512("SHA-512"),
+                    SHA512_224("SHA-512/224"),
+                    SHA512_256("SHA-512/256");
+
+                    @JsonValue
+                    private final String algName;
+
+                    Alg(String algName) {
+                        this.algName = algName;
+                    }
+
+                    @Override
+                    public String toString() {
+                        return algName;
+                    }
+                }
             }
         }
     }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
@@ -198,6 +198,7 @@ public class EiffelEvent {
             IUT,
             MODIFIED_ANNOUNCEMENT,
             PARTIALLY_RESOLVED_ISSUE,
+            PRECURSOR,
             PREVIOUS_ACTIVITY_EXECUTION,
             PREVIOUS_VERSION,
             RESOLVED_ISSUE,
@@ -217,6 +218,8 @@ public class EiffelEvent {
     public static class Meta {
         @JsonInclude(JsonInclude.Include.ALWAYS)
         private UUID id = UUID.randomUUID();
+
+        private String schemaUri;
 
         private Source source = new Source();
 
@@ -248,6 +251,14 @@ public class EiffelEvent {
 
         public void setId(UUID id) {
             this.id = id;
+        }
+
+        public String getSchemaUri() {
+            return schemaUri;
+        }
+
+        public void setSchemaUri(String schemaUri) {
+            this.schemaUri = schemaUri;
         }
 
         public Source getSource() {
@@ -289,6 +300,7 @@ public class EiffelEvent {
             Meta meta = (Meta) o;
             return time == meta.time &&
                     id.equals(meta.id) &&
+                    Objects.equals(schemaUri, meta.schemaUri) &&
                     Objects.equals(source, meta.source) &&
                     tags.equals(meta.tags) &&
                     type.equals(meta.type) &&
@@ -297,13 +309,14 @@ public class EiffelEvent {
 
         @Override
         public int hashCode() {
-            return Objects.hash(id, source, time, tags, type, version);
+            return Objects.hash(id, schemaUri, source, time, tags, type, version);
         }
 
         @Override
         public String toString() {
             return new ToStringBuilder(this)
                     .append("id", id)
+                    .append("schemaUri", schemaUri)
                     .append("source", source)
                     .append("time", time)
                     .append("tags", tags)

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -110,8 +114,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -110,8 +114,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -94,8 +98,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityCanceledEvent"]
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityCanceledEvent/3.2.0.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityCanceledEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additonalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -148,8 +152,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -148,8 +152,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -132,8 +136,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -161,8 +178,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -170,8 +187,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityFinishedEvent"]
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -170,8 +187,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityFinishedEvent/3.3.0.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "UNSUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "conclusion"
+          ]
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false,
+      "required": [
+        "outcome"
+      ]
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -129,8 +133,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -129,8 +133,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -113,8 +117,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -113,8 +117,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.0.0" ],
+          "enum": [
+            "4.0.0"
+          ],
           "default": "4.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -142,8 +159,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
+          "enum": [
+            "4.1.0"
+          ],
           "default": "4.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -151,8 +168,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityStartedEvent"]
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.2.0" ],
+          "enum": [
+            "4.2.0"
+          ],
           "default": "4.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -151,8 +168,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityStartedEvent/4.3.0.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.3.0"
+          ],
+          "default": "4.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "executionUri": {
+          "type": "string"
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -150,8 +154,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -150,8 +154,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -134,8 +138,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -134,8 +138,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.0.0" ],
+          "enum": [
+            "4.0.0"
+          ],
           "default": "4.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -163,8 +180,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelActivityTriggeredEvent"]
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
+          "enum": [
+            "4.1.0"
+          ],
           "default": "4.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -163,8 +180,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelActivityTriggeredEvent/4.2.0.json
@@ -1,0 +1,231 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelActivityTriggeredEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.2.0"
+          ],
+          "default": "4.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "MANUAL",
+                  "EIFFEL_EVENT",
+                  "SOURCE_CHANGE",
+                  "TIMER",
+                  "OTHER"
+                ]
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "executionType": {
+          "type": "string",
+          "enum": [
+            "MANUAL",
+            "SEMI_AUTOMATED",
+            "AUTOMATED",
+            "OTHER"
+          ]
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -110,7 +114,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -120,8 +131,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -110,7 +114,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -120,8 +131,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -94,7 +98,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -104,8 +115,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,7 +140,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -133,8 +157,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelAnnouncementPublishedEvent" ]
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,7 +140,14 @@
         },
         "severity": {
           "type": "string",
-          "enum": ["MINOR", "MAJOR", "CRITICAL", "BLOCKER", "CLOSED", "CANCELED"]
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
         },
         "customData": {
           "type": "array",
@@ -133,8 +157,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelAnnouncementPublishedEvent/3.2.0.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelAnnouncementPublishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "heading": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "severity": {
+          "type": "string",
+          "enum": [
+            "MINOR",
+            "MAJOR",
+            "CRITICAL",
+            "BLOCKER",
+            "CLOSED",
+            "CANCELED"
+          ]
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "heading",
+        "body",
+        "severity"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -207,8 +211,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -207,8 +211,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -145,8 +149,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -174,8 +191,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactCreatedEvent"]
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -174,8 +191,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.2.0.json
@@ -1,0 +1,242 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "pattern": "^pkg:"
+        },
+        "fileInformation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "buildCommand": {
+          "type": "string"
+        },
+        "requiresImplementation": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ANY",
+            "EXACTLY_ONE",
+            "AT_LEAST_ONE"
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "implements": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactCreatedEvent/3.3.0.json
@@ -1,0 +1,267 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "identity": {
+          "type": "string",
+          "pattern": "^pkg:"
+        },
+        "fileInformation": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "integrityProtection": {
+                "type": "object",
+                "properties": {
+                  "alg": {
+                    "type": "string",
+                    "enum": [
+                      "SHA-224",
+                      "SHA-256",
+                      "SHA-384",
+                      "SHA-512",
+                      "SHA-512/224",
+                      "SHA-512/256"
+                    ]
+                  },
+                  "digest": {
+                    "type": "string",
+                    "pattern": "^[0-9a-f]+$"
+                  }
+                },
+                "required": [
+                  "alg",
+                  "digest"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "buildCommand": {
+          "type": "string"
+        },
+        "requiresImplementation": {
+          "type": "string",
+          "enum": [
+            "NONE",
+            "ANY",
+            "EXACTLY_ONE",
+            "AT_LEAST_ONE"
+          ]
+        },
+        "dependsOn": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "implements": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^pkg:"
+          }
+        },
+        "name": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "identity"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -132,8 +136,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -132,8 +136,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -116,8 +120,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -145,8 +162,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -148,8 +165,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelArtifactPublishedEvent"]
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -148,8 +165,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactPublishedEvent/3.3.0.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactPublishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "locations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ARTIFACTORY",
+                  "NEXUS",
+                  "PLAIN",
+                  "OTHER"
+                ]
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "locations"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -107,8 +111,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -107,8 +111,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -91,8 +95,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -120,8 +137,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelArtifactReusedEvent" ]
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -120,8 +137,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelArtifactReusedEvent/3.2.0.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelArtifactReusedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -113,8 +117,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -113,8 +117,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -97,8 +101,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -126,8 +143,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -126,8 +143,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelCompositionDefinedEvent" ]
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -126,8 +143,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelCompositionDefinedEvent/3.3.0.json
@@ -1,0 +1,194 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelCompositionDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -104,7 +108,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -132,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -104,7 +108,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -132,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -88,7 +92,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -116,8 +124,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -117,7 +134,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -145,8 +166,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": ["EiffelConfidenceLevelModifiedEvent"]
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -117,7 +134,11 @@
         },
         "value": {
           "type": "string",
-          "enum": ["SUCCESS", "FAILURE", "INCONCLUSIVE"]
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
         },
         "issuer": {
           "type": "object",
@@ -145,8 +166,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelConfidenceLevelModifiedEvent/3.2.0.json
@@ -1,0 +1,218 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelConfidenceLevelModifiedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "type": "string",
+          "enum": [
+            "SUCCESS",
+            "FAILURE",
+            "INCONCLUSIVE"
+          ]
+        },
+        "issuer": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -135,8 +139,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -135,8 +139,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -119,8 +123,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -148,8 +165,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -148,8 +165,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelEnvironmentDefinedEvent" ]
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -148,8 +165,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelEnvironmentDefinedEvent/3.3.0.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelEnvironmentDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "image": {
+          "type": "string"
+        },
+        "host": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "user": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "user"
+          ],
+          "additionalProperties": false
+        },
+        "uri": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -122,8 +126,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -122,8 +126,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -106,8 +110,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -135,8 +152,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelFlowContextDefinedEvent" ]
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -135,8 +152,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelFlowContextDefinedEvent/3.2.0.json
@@ -1,0 +1,200 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelFlowContextDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "product": {
+          "type": "string"
+        },
+        "project": {
+          "type": "string"
+        },
+        "program": {
+          "type": "string"
+        },
+        "track": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueDefinedEvent" ]
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -130,8 +134,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueDefinedEvent" ]
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -114,8 +118,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueDefinedEvent" ]
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -143,8 +160,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueDefinedEvent" ]
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -143,8 +160,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueDefinedEvent/3.2.0.json
@@ -1,0 +1,208 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelIssueDefinedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "BUG",
+            "IMPROVEMENT",
+            "FEATURE",
+            "WORK_ITEM",
+            "REQUIREMENT",
+            "OTHER"
+          ]
+        },
+        "tracker": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "uri": {
+          "type": "string"
+        },
+        "title": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "type",
+        "tracker",
+        "id",
+        "uri"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -151,8 +155,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -151,8 +155,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -107,8 +111,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -91,8 +95,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.0.0" ],
+          "enum": [
+            "4.0.0"
+          ],
           "default": "4.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -120,8 +137,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelIssueVerifiedEvent" ]
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
+          "enum": [
+            "4.1.0"
+          ],
           "default": "4.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -120,8 +137,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelIssueVerifiedEvent/4.2.0.json
@@ -1,0 +1,185 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelIssueVerifiedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.2.0"
+          ],
+          "default": "4.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -282,8 +286,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -282,8 +286,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -239,8 +243,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -223,8 +227,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.0.0" ],
+          "enum": [
+            "4.0.0"
+          ],
           "default": "4.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -252,8 +269,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeCreatedEvent" ]
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
+          "enum": [
+            "4.1.0"
+          ],
           "default": "4.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -252,8 +269,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeCreatedEvent/4.2.0.json
@@ -1,0 +1,317 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelSourceChangeCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.2.0"
+          ],
+          "default": "4.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "author": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "change": {
+          "type": "object",
+          "properties": {
+            "insertions": {
+              "type": "integer"
+            },
+            "deletions": {
+              "type": "integer"
+            },
+            "files": {
+              "type": "string"
+            },
+            "details": {
+              "type": "string"
+            },
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "gitIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "svnIdentifier": {
+          "type": "object",
+          "properties": {
+            "revision": {
+              "type": "integer"
+            },
+            "directory": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "revision",
+            "directory",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "ccCompositeIdentifier": {
+          "type": "object",
+          "properties": {
+            "vobs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "branch": {
+              "type": "string"
+            },
+            "configSpec": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "vobs",
+            "branch",
+            "configSpec"
+          ],
+          "additionalProperties": false
+        },
+        "hgIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -215,8 +219,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -215,8 +219,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -199,8 +203,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -228,8 +245,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelSourceChangeSubmittedEvent" ]
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -228,8 +245,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelSourceChangeSubmittedEvent/3.2.0.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelSourceChangeSubmittedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "submitter": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "group": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "gitIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "svnIdentifier": {
+          "type": "object",
+          "properties": {
+            "revision": {
+              "type": "integer"
+            },
+            "directory": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "revision",
+            "directory",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "ccCompositeIdentifier": {
+          "type": "object",
+          "properties": {
+            "vobs": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "branch": {
+              "type": "string"
+            },
+            "configSpec": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "vobs",
+            "branch",
+            "configSpec"
+          ],
+          "additionalProperties": false
+        },
+        "hgIdentifier": {
+          "type": "object",
+          "properties": {
+            "commitId": {
+              "type": "string"
+            },
+            "branch": {
+              "type": "string"
+            },
+            "repoName": {
+              "type": "string"
+            },
+            "repoUri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "commitId",
+            "repoUri"
+          ],
+          "additionalProperties": false
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseCanceledEvent" ]
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -110,8 +114,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseCanceledEvent" ]
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -110,8 +114,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseCanceledEvent" ]
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -94,8 +98,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseCanceledEvent" ]
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseCanceledEvent" ]
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -123,8 +140,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseCanceledEvent/3.2.0.json
@@ -1,0 +1,188 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseCanceledEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "reason": {
+          "type": "string"
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -131,8 +135,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "additionalProperties": false
               }
@@ -171,8 +174,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.0.1.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.0.1.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.1" ],
+          "enum": [
+            "1.0.1"
+          ],
           "default": "1.0.1"
         },
         "time": {
@@ -131,8 +135,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -175,8 +178,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -131,8 +135,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -175,8 +178,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -115,8 +119,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -159,8 +162,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -144,8 +161,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -188,8 +204,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -144,8 +161,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -197,8 +213,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseFinishedEvent" ]
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -144,8 +161,7 @@
                   "name": {
                     "type": "string"
                   },
-                  "value": {
-                  }
+                  "value": {}
                 },
                 "required": [
                   "name",
@@ -197,8 +213,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseFinishedEvent/3.3.0.json
@@ -1,0 +1,264 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "PASSED",
+                "FAILED",
+                "INCONCLUSIVE"
+              ]
+            },
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            },
+            "metrics": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "value": {}
+                },
+                "required": [
+                  "name",
+                  "value"
+                ],
+                "additionalProperties": false
+              }
+            }
+          },
+          "required": [
+            "verdict",
+            "conclusion"
+          ],
+          "additionalProperties": false
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "outcome"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -129,8 +133,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -129,8 +133,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -113,8 +117,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -142,8 +159,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -151,8 +168,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseStartedEvent" ]
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -151,8 +168,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseStartedEvent/3.3.0.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "executor": {
+          "type": "string"
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseTriggeredEvent" ]
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -185,8 +189,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseTriggeredEvent" ]
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -185,8 +189,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseTriggeredEvent" ]
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -169,8 +173,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseTriggeredEvent" ]
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -198,8 +215,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestCaseTriggeredEvent" ]
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -198,8 +215,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestCaseTriggeredEvent/3.2.0.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestCaseTriggeredEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.2.0"
+          ],
+          "default": "3.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "testCase": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "version": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "recipeId": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "triggers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": [
+                  "MANUAL",
+                  "EIFFEL_EVENT",
+                  "SOURCE_CHANGE",
+                  "TIMER",
+                  "OTHER"
+                ]
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "type"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "executionType": {
+          "type": "string",
+          "enum": [
+            "MANUAL",
+            "SEMI_AUTOMATED",
+            "AUTOMATED",
+            "OTHER"
+          ]
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "testCase"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -204,8 +208,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -166,8 +170,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -219,8 +222,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/2.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.1.0" ],
+          "enum": [
+            "2.1.0"
+          ],
           "default": "2.1.0"
         },
         "time": {
@@ -166,8 +170,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -219,8 +222,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -150,8 +154,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -203,8 +206,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.0.0" ],
+          "enum": [
+            "4.0.0"
+          ],
           "default": "4.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -179,8 +196,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -232,8 +248,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.0" ],
+          "enum": [
+            "4.1.0"
+          ],
           "default": "4.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -179,8 +196,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -232,8 +248,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.1.1.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestExecutionRecipeCollectionCreatedEvent" ]
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "4.1.1" ],
+          "enum": [
+            "4.1.1"
+          ],
           "default": "4.1.1"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -179,8 +196,7 @@
                           "key": {
                             "type": "string"
                           },
-                          "value": {
-                          }
+                          "value": {}
                         },
                         "required": [
                           "key",
@@ -232,8 +248,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.2.0.json
@@ -1,0 +1,299 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.2.0"
+          ],
+          "default": "4.2.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {}
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestExecutionRecipeCollectionCreatedEvent/4.3.0.json
@@ -1,0 +1,302 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestExecutionRecipeCollectionCreatedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "4.3.0"
+          ],
+          "default": "4.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "selectionStrategy": {
+          "type": "object",
+          "properties": {
+            "tracker": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "id"
+          ],
+          "additionalProperties": false
+        },
+        "batchesUri": {
+          "type": "string"
+        },
+        "batches": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "priority": {
+                "type": "integer"
+              },
+              "recipes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "string",
+                      "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "testCase": {
+                      "type": "object",
+                      "properties": {
+                        "tracker": {
+                          "type": "string"
+                        },
+                        "id": {
+                          "type": "string"
+                        },
+                        "version": {
+                          "type": "string"
+                        },
+                        "uri": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "id"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "constraints": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "key": {
+                            "type": "string"
+                          },
+                          "value": {}
+                        },
+                        "required": [
+                          "key",
+                          "value"
+                        ],
+                        "additionalProperties": false
+                      }
+                    }
+                  },
+                  "required": [
+                    "id",
+                    "testCase"
+                  ],
+                  "additionalProperties": false
+                }
+              },
+              "dependencies": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "dependent": {
+                      "type": "string"
+                    },
+                    "dependency": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "dependent",
+                    "dependency"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            },
+            "required": [
+              "priority",
+              "recipes"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "selectionStrategy"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -153,8 +157,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -153,8 +157,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -137,8 +141,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -166,8 +183,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -175,8 +192,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteFinishedEvent" ]
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -175,8 +192,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteFinishedEvent/3.3.0.json
@@ -1,0 +1,240 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestSuiteFinishedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "outcome": {
+          "type": "object",
+          "properties": {
+            "verdict": {
+              "type": "string",
+              "enum": [
+                "PASSED",
+                "FAILED",
+                "INCONCLUSIVE"
+              ]
+            },
+            "conclusion": {
+              "type": "string",
+              "enum": [
+                "SUCCESSFUL",
+                "FAILED",
+                "ABORTED",
+                "TIMED_OUT",
+                "INCONCLUSIVE"
+              ]
+            },
+            "description": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "persistentLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/1.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/1.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.0.0" ],
+          "enum": [
+            "1.0.0"
+          ],
           "default": "1.0.0"
         },
         "time": {
@@ -160,8 +164,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/1.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/1.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "1.1.0" ],
+          "enum": [
+            "1.1.0"
+          ],
           "default": "1.1.0"
         },
         "time": {
@@ -160,8 +164,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/2.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/2.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "2.0.0" ],
+          "enum": [
+            "2.0.0"
+          ],
           "default": "2.0.0"
         },
         "time": {
@@ -144,8 +148,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.0.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.0.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.0.0" ],
+          "enum": [
+            "3.0.0"
+          ],
           "default": "3.0.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -173,8 +190,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.1.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.1.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.1.0" ],
+          "enum": [
+            "3.1.0"
+          ],
           "default": "3.1.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -182,8 +199,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.2.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.2.0.json
@@ -11,11 +11,15 @@
         },
         "type": {
           "type": "string",
-          "enum": [ "EiffelTestSuiteStartedEvent" ]
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
         },
         "version": {
           "type": "string",
-          "enum": [ "3.2.0" ],
+          "enum": [
+            "3.2.0"
+          ],
           "default": "3.2.0"
         },
         "time": {
@@ -63,7 +67,20 @@
                 },
                 "alg": {
                   "type": "string",
-                  "enum": ["HS256", "HS384", "HS512", "RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
                 },
                 "publicKey": {
                   "type": "string"
@@ -182,8 +199,7 @@
               "key": {
                 "type": "string"
               },
-              "value": {
-              }
+              "value": {}
             },
             "required": [
               "key",

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.3.0.json
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/BundledSchemaProvider/EiffelTestSuiteStartedEvent/3.3.0.json
@@ -1,0 +1,250 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "meta": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "EiffelTestSuiteStartedEvent"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "enum": [
+            "3.3.0"
+          ],
+          "default": "3.3.0"
+        },
+        "time": {
+          "type": "integer"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "source": {
+          "type": "object",
+          "properties": {
+            "domainId": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            },
+            "serializer": {
+              "type": "string",
+              "pattern": "^pkg:"
+            },
+            "uri": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        },
+        "security": {
+          "type": "object",
+          "properties": {
+            "authorIdentity": {
+              "type": "string"
+            },
+            "integrityProtection": {
+              "type": "object",
+              "properties": {
+                "signature": {
+                  "type": "string"
+                },
+                "alg": {
+                  "type": "string",
+                  "enum": [
+                    "HS256",
+                    "HS384",
+                    "HS512",
+                    "RS256",
+                    "RS384",
+                    "RS512",
+                    "ES256",
+                    "ES384",
+                    "ES512",
+                    "PS256",
+                    "PS384",
+                    "PS512"
+                  ]
+                },
+                "publicKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "signature",
+                "alg"
+              ],
+              "additionalProperties": false
+            },
+            "sequenceProtection": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "sequenceName": {
+                    "type": "string"
+                  },
+                  "position": {
+                    "type": "integer"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "sequenceName",
+                  "position"
+                ]
+              }
+            }
+          },
+          "additionalProperties": false,
+          "required": [
+            "authorIdentity"
+          ]
+        },
+        "schemaUri": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "type",
+        "version",
+        "time"
+      ],
+      "additionalProperties": false
+    },
+    "data": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "categories": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "ACCESSIBILITY",
+              "BACKUP_RECOVERY",
+              "COMPATIBILITY",
+              "CONVERSION",
+              "DISASTER_RECOVERY",
+              "FUNCTIONAL",
+              "INSTALLABILITY",
+              "INTEROPERABILITY",
+              "LOCALIZATION",
+              "MAINTAINABILITY",
+              "PERFORMANCE",
+              "PORTABILITY",
+              "PROCEDURE",
+              "RELIABILITY",
+              "SECURITY",
+              "STABILITY",
+              "USABILITY"
+            ]
+          }
+        },
+        "liveLogs": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "mediaType": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "uri": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "name",
+              "uri"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "customData": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string"
+              },
+              "value": {}
+            },
+            "required": [
+              "key",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "additionalProperties": false
+    },
+    "links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string",
+            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+          },
+          "domainId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "target"
+        ],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": [
+    "meta",
+    "data",
+    "links"
+  ],
+  "additionalProperties": false
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
@@ -51,13 +51,28 @@ public class EiffelEventTest {
 
     @Test
     public void testJsonDeserialization_WithLyonEvent() throws IOException {
-        // Make sure we can deserialize an event with a newer version than the default,
+        // Make sure we can deserialize an event from the Lyon edition,
         // and that an attribute that was added in that version is picked up.
         EiffelEvent event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent_with_domainid_link.json"),
                 EiffelEvent.class);
         assertThat(event.getMeta().getVersion(), is("3.2.0"));
         assertThat(event.getLinks().get(0).getDomainId(), is("example.com"));
+    }
+
+    @Test
+    public void testJsonDeserialization_WithAricaEvent() throws IOException {
+        // Make sure we can deserialize an event from the Arica edition,
+        // and that attributes that were added in that version are picked up.
+        EiffelArtifactCreatedEvent event = new ObjectMapper().readValue(
+                getClass().getResourceAsStream("EiffelArtifactCreatedEvent_with_digest_and_schemauri.json"),
+                EiffelArtifactCreatedEvent.class);
+        assertThat(event.getMeta().getVersion(), is("3.3.0"));
+        assertThat(event.getMeta().getSchemaUri(), is("https://example.com/schema.json"));
+        EiffelArtifactCreatedEvent.Data.FileInformation.IntegrityProtection ip =
+                event.getData().getFileInformation().get(0).getIntegrityProtection();
+        assertThat(ip.getAlg(), is(EiffelArtifactCreatedEvent.Data.FileInformation.IntegrityProtection.Alg.SHA256));
+        assertThat(ip.getDigest(), is("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     }
 
     @Test(expected = InvalidJsonPayloadException.class)

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent_with_digest_and_schemauri.json
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent_with_digest_and_schemauri.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "type": "EiffelArtifactCreatedEvent",
+    "version": "3.3.0",
+    "time": 1234567890,
+    "id": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee0",
+    "schemaUri": "https://example.com/schema.json"
+  },
+  "data": {
+    "identity": "pkg:generic/empty-file",
+    "fileInformation": [
+      {
+        "name": "empty-file.txt",
+        "integrityProtection": {
+          "alg": "SHA-256",
+          "digest": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        }
+      }
+    ],
+    "name": "This artifact is just an empty file"
+  },
+  "links": [
+    {
+      "type": "CAUSE",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+    },
+    {
+      "type": "COMPOSITION",
+      "target": "aaaaaaaa-bbbb-5ccc-8ddd-eeeeeeeeeee1"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #76 by adding the schemas introduced in the [protocol's Arica edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-arica) so that users of the sendEiffelEvent pipeline step can send the new events without getting stopped by the validator. The events emitted by the plugin itself will continue to stick to the Paris edition.

Because the schema files were slightly reformatted between Lyon and Arica all schema files appear to have changed but it's only whitespace changes.

Apart from just adding the schema files for the validation we also had to add class attributes for the event fields introduced in Arica for the events where we have corresponding classes. Otherwise added event fields would get lost upon deserialization.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
