### PR TITLE
Hide non-essential configuration options behind an Advanced button

### DIFF
--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
@@ -53,18 +53,20 @@ f.section(title: "Eiffel Broadcaster Plugin") {
     f.entry(title: "Routing Key", field: "routingKey", help: l+"help-routing-key.html") {
         f.textbox("value":instance.routingKey)
     }
-    f.entry(title: "Application Id", field: "appId", help: l+"help-application-id.html") {
-        f.textbox("value":instance.appId)
-    }
-    f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
-        f.checkbox(field: "persistentDelivery", checked: instance.persistentDelivery)
-    }
-    f.entry(title: "Activity Categories", field: "activityCategories", help: l+"help-activity-categories.html") {
-        f.textarea(value: instance.activityCategories)
-    }
-    f.entry(title: "Hostname source", field: "hostnameSource", help: l+"help-hostname-source.html") {
-        f.enum {
-            raw(my.description)
+    f.advanced() {
+        f.entry(title: "Application Id", field: "appId", help: l+"help-application-id.html") {
+            f.textbox("value":instance.appId)
+        }
+        f.entry(title: "Persistent Delivery mode", help: l+"help-persistent-delivery.html") {
+            f.checkbox(field: "persistentDelivery", checked: instance.persistentDelivery)
+        }
+        f.entry(title: "Activity Categories", field: "activityCategories", help: l+"help-activity-categories.html") {
+            f.textarea(value: instance.activityCategories)
+        }
+        f.entry(title: "Hostname source", field: "hostnameSource", help: l+"help-hostname-source.html") {
+            f.enum {
+                raw(my.description)
+            }
         }
     }
 }


### PR DESCRIPTION
As a first step towards #69, move several of the available configuration options behind an Advanced button. They're "expert" options with reasonable default values, i.e. a first-time user shouldn't have to spend time on them.

Ideally the routing key option should be hidden too, but we can't do that until its default value has been overhauled.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
