### PR TITLE
Docs: Fix incorrect event type reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ for each EiffelArtifactCreatedEvent that has been recorded in the build using
 a sendEiffelEvent step with the `publishArtifact` argument enabled and for
 each artifact recorded in the specified JSON files in the workspace.
 
-This requires that each EiffelArtifactPublishedEvent has at least one file
+This requires that each EiffelArtifactCreatedEvent has at least one file
 defined in its `data.fileInformation` array and that each relative file path
 in `data.fileInformation.name` matches a Jenkins artifact in the build.
 Because of the latter requirement it's normally used after an


### PR DESCRIPTION
README.md incorrectly referenced the wrong event type in the description of the publishEiffelArtifacts pipeline step.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
