### PR TITLE
Fix startup race condition that put the outbound message queue in a bad state

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -58,7 +58,7 @@ public final class MQConnection implements ShutdownListener {
     private static final int SENDMESSAGE_TIMEOUT = 100;
     private static final int CONNECTION_WAIT = 10000;
 
-    private boolean initialized = false;
+    private volatile boolean initialized = false;
     private String userName;
     private Secret userPassword;
     private String serverUri;


### PR DESCRIPTION
For some time there's been a race condition during Jenkins startup between the sending of the first event and the initialization of the message queue thread.

The AMQP configuration is passed to MQConnection via initialized(), called from EiffelBroadcasterConfig#configure(). Until this has happened, the MQConnection's AMQP URL will be null and any attempt to send an event will trigger an NPE. To make matters worse, the message queue thread startup code in MQConnection#addMessageToQueue() had a bug it would attempt to restart a crashed thread rather than create a new one, resulting in an IllegalStateException.

We solve this by introducing an MQConnection#initialized attribute that's set to true only after we've received the configuration, and until then the message queue thread won't be started. We still post messages to the queue, though, so any early messages will still be sent.

While we're at it we solve the bug that resulted in the IllegalStateException, allowing a crashed message queue thread to be recoverable.

I couldn't find a good way of testing this bugfix. Verifying a startup race condition with a JenkinsRule-based instance isn't obvious and while it'd be easy to add a unit test for the MQConnection class, it's a singleton class so we only get one shot per test session.

Fixes #81

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
