### PR TITLE
Make event publishing more reliable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,3 @@
-buildPlugin()
+buildPlugin(
+    platforms: ['linux']
+)

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <properties>
         <jenkins.version>2.303.3</jenkins.version>
 
-        <amqp.client.version>4.8.0</amqp.client.version>
+        <amqp.client.version>5.6.0</amqp.client.version>
         <commons.lang3.version>3.11</commons.lang3.version>
         <commons.validator.version>1.7</commons.validator.version>
         <jenkins-test-harness.version>2.72</jenkins-test-harness.version>

--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,11 @@
             <version>${jmockit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>rabbitmq</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>
@@ -162,6 +167,13 @@
                 <version>1500.ve4d05cd32975</version>
                 <scope>import</scope>
                 <type>pom</type>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>testcontainers-bom</artifactId>
+                <version>1.17.6</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <artifactId>rabbitmq</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>toxiproxy</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
 public final class MQConnection implements ShutdownListener {
     private static final Logger logger = LoggerFactory.getLogger(MQConnection.class);
     private static final int HEARTBEAT_INTERVAL = 30;
-    private static final int MESSAGE_QUEUE_SIZE = 1000;
     private static final int SENDMESSAGE_TIMEOUT = 100;
     private static final int CONNECTION_WAIT = 10000;
 
@@ -62,7 +61,7 @@ public final class MQConnection implements ShutdownListener {
     private String virtualHost;
     private Connection connection = null;
 
-    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue(MESSAGE_QUEUE_SIZE);
+    private volatile LinkedBlockingQueue messageQueue = new LinkedBlockingQueue();
     private Thread messageQueueThread;
 
     /* False if messages should not be added to the queue */
@@ -185,9 +184,7 @@ public final class MQConnection implements ShutdownListener {
         startMessageQueueThread();
         MessageData messageData = new MessageData(exchange, routingKey, props, body);
         waitForQueue(); // Block execution until queue is available
-        if (!messageQueue.offer(messageData)) {
-            logger.error("addMessageToQueue() failed, RabbitMQ queue is full!");
-        }
+        messageQueue.offer(messageData);
     }
 
     /**

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -177,6 +177,15 @@ public final class MQConnection implements ShutdownListener {
     }
 
     /**
+     * Get the number of currently outstanding confirms.
+     *
+     * @return the number of currently outstanding confirms
+     */
+    public int getSizeOutstandingConfirms() {
+        return outstandingConfirms.size();
+    }
+
+    /**
      * Puts a message in the message queue.
      *
      * @param exchange the exchange to publish the message to

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -186,6 +186,13 @@ public final class MQConnection implements ShutdownListener {
     }
 
     /**
+     * Clear the outstanding confirms list, useful when testing.
+     */
+    public void clearOutstandingConfirms() {
+        outstandingConfirms.clear();
+    }
+
+    /**
      * Puts a message in the message queue.
      *
      * @param exchange the exchange to publish the message to

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -43,7 +43,8 @@ import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
 import org.testcontainers.containers.ToxiproxyContainer;
 
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.testcontainers.containers.Network.newNetwork;
 
 /**
@@ -85,7 +86,7 @@ public class ConnectionIntegrationTest {
     @Before
     public void createProxyConnection() {
         EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        assertNotNull("No config available: EiffelBroadcasterConfig", config);
+        assertThat(config, is(notNullValue()));
         TestUtil.setDefaultConfig(config);
         config.setServerUri(formatProxyServerUri());
 
@@ -140,7 +141,7 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals(expectedMessages, actualMessages);
+        assertThat(actualMessages, is(expectedMessages));
     }
 
     /**
@@ -159,7 +160,7 @@ public class ConnectionIntegrationTest {
                 TestUtil.QUEUE_NAME
         );
         Thread.sleep(2000); // Make sure the ACKs have some time to get processed.
-        assertEquals(0, conn.getSizeOutstandingConfirms());
+        assertThat(conn.getSizeOutstandingConfirms(), is(0));
     }
 
     /**
@@ -183,7 +184,7 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals(expectedMessages, actualMessages);
+        assertThat(actualMessages, is(expectedMessages));
     }
 
     /**
@@ -206,7 +207,7 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals(expectedMessages, actualMessages);
+        assertThat(actualMessages, is(expectedMessages));
     }
 
     /**
@@ -236,7 +237,7 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals(expectedMessages, actualMessages);
+        assertThat(actualMessages, is(expectedMessages));
     }
 
     /**
@@ -256,7 +257,7 @@ public class ConnectionIntegrationTest {
                 messageCount,
                 30,
                 TestUtil.QUEUE_NAME);
-        assertEquals(expectedMessages, actualMessages);
+        assertThat(actualMessages, is(expectedMessages));
     }
 
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -25,18 +25,24 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Network;
 import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.containers.ToxiproxyContainer;
 
 import static org.junit.Assert.*;
+import static org.testcontainers.containers.Network.newNetwork;
 
 /**
  * Integration tests for the MQConnection
@@ -44,32 +50,104 @@ import static org.junit.Assert.*;
  * @author Hampus Johansson
  */
 public class ConnectionIntegrationTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConnectionIntegrationTest.class);
+    private static final String TOXIPROXY_NETWORK_ALIAS = "toxiproxy";
     private static final int DEFAULT_MESSAGE_WAIT = 10;
 
     RabbitMQContainer defaultMQContainer = TestUtil.getDefaultMQContainer();
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+
+    @Rule
+    public Network network = newNetwork();
+
+    private ToxiproxyContainer toxiproxy = new ToxiproxyContainer()
+            .withNetwork(network)
+            .withNetworkAliases(TOXIPROXY_NETWORK_ALIAS);
 
     @Rule
     public TestRule chain = RuleChain
-            .outerRule(defaultMQContainer)
+            .outerRule(defaultMQContainer.withNetwork(network))
+            .around(toxiproxy)
             .around(new JenkinsRule());
+
+    /**
+     * Get the toxiproxy for the MQ container
+     */
+    private ToxiproxyContainer.ContainerProxy getProxy() {
+        return toxiproxy.getProxy(defaultMQContainer, TestUtil.PORT);
+    }
+
+    /**
+     * Creates a connection to RabbitMQ through toxiproxy and configures exchanges, passwords etc.
+     */
+    @Before
+    public void createProxyConnection() {
+        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        assertNotNull("No config available: EiffelBroadcasterConfig", config);
+        TestUtil.setDefaultConfig(config);
+        config.setServerUri(formatProxyServerUri());
+
+        MQConnection conn = MQConnection.getInstance();
+        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+    }
+
+    /**
+     * Format a URI to toxiproxy, which will be forwarded to RabbitMQ.
+     */
+    private String formatProxyServerUri() {
+        ToxiproxyContainer.ContainerProxy proxy = getProxy();
+        final String ipAddressViaToxiproxy = proxy.getContainerIpAddress();
+        final int portViaToxiproxy = proxy.getProxyPort();
+        return "amqp://" + ipAddressViaToxiproxy + ":" + portViaToxiproxy;
+    }
+
+    /**
+     * Publishes a single event and silently ignores any errors. Use this advisedly
+     * and only when a later stage of the test will reveal that the sending failed.
+     *
+     * @param event the event to publish
+     */
+    private void publishSilently(final EiffelEvent event) {
+        try {
+            Util.mustPublishEvent(event);
+        } catch (Exception e) {
+            LOGGER.error("Unexpected exception", e);
+        }
+    }
 
     /**
      * Test that the publisher sends messages correctly.
      */
     @Test
-    public void testSentMessagesHaveCorrectFormat()
-            throws EventValidationFailedException, IOException, InterruptedException, SchemaUnavailableException {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        assertNotNull("No config available: EiffelBroadcasterConfig", config);
-        TestUtil.setDefaultConfig(config);
-        config.setServerUri(defaultMQContainer.getAmqpUrl());
-
+    public void testSentMessagesHaveCorrectFormat() throws InterruptedException, IOException {
         MQConnection conn = MQConnection.getInstance();
-        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
-
         int messageCount = 10;
         ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
-        TestUtil.sendEventsWithinTimeframe(expectedMessages, DEFAULT_MESSAGE_WAIT);
+        expectedMessages.forEach(this::publishSilently);
+        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+                conn,
+                messageCount,
+                DEFAULT_MESSAGE_WAIT,
+                TestUtil.QUEUE_NAME
+        );
+        assertEquals(expectedMessages, actualMessages);
+    }
+
+    /**
+     * Test that the publisher won't lose messages when the connection is closed.
+     */
+    @Test
+    public void testSendMessagesHandlesClosedConnection() throws InterruptedException, IOException {
+        MQConnection conn = MQConnection.getInstance();
+        int messageCount = 1000;
+        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+
+        getProxy().setConnectionCut(true);
+        executor.submit(() -> {
+            expectedMessages.forEach(this::publishSilently);
+        });
+        Thread.sleep(1000);
+        getProxy().setConnectionCut(false);
         ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
                 conn,
                 messageCount,

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -141,7 +141,25 @@ public class ConnectionIntegrationTest {
                 TestUtil.QUEUE_NAME
         );
         assertEquals(expectedMessages, actualMessages);
-        assertEquals( 0, conn.getSizeOutstandingConfirms());
+    }
+
+    /**
+     * Test that the publisher receives ACKs.
+     */
+    @Test
+    public void testSentMessagesReceiveACKs() throws IOException, InterruptedException {
+        MQConnection conn = MQConnection.getInstance();
+        int messageCount = 25;
+        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        expectedMessages.forEach(this::publishSilently);
+        TestUtil.waitForMessages(
+                conn,
+                messageCount,
+                DEFAULT_MESSAGE_WAIT,
+                TestUtil.QUEUE_NAME
+        );
+        Thread.sleep(2000); // Make sure the ACKs have some time to get processed.
+        assertEquals(0, conn.getSizeOutstandingConfirms());
     }
 
     /**
@@ -165,7 +183,6 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 
@@ -189,7 +206,6 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 
@@ -220,7 +236,6 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
-        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 
@@ -241,7 +256,6 @@ public class ConnectionIntegrationTest {
                 messageCount,
                 30,
                 TestUtil.QUEUE_NAME);
-        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -1,0 +1,82 @@
+/**
+ The MIT License
+
+ Copyright 2020 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
+import java.io.IOException;
+import java.util.ArrayList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.testcontainers.containers.RabbitMQContainer;
+
+import static org.junit.Assert.*;
+
+/**
+ * Integration tests for the MQConnection
+ *
+ * @author Hampus Johansson
+ */
+public class ConnectionIntegrationTest {
+    private static final int DEFAULT_MESSAGE_WAIT = 10;
+
+    RabbitMQContainer defaultMQContainer = TestUtil.getDefaultMQContainer();
+
+    @Rule
+    public TestRule chain = RuleChain
+            .outerRule(defaultMQContainer)
+            .around(new JenkinsRule());
+
+    /**
+     * Test that the publisher sends messages correctly.
+     */
+    @Test
+    public void testSentMessagesHaveCorrectFormat()
+            throws EventValidationFailedException, IOException, InterruptedException, SchemaUnavailableException {
+        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        assertNotNull("No config available: EiffelBroadcasterConfig", config);
+        TestUtil.setDefaultConfig(config);
+        config.setServerUri(defaultMQContainer.getAmqpUrl());
+
+        MQConnection conn = MQConnection.getInstance();
+        conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
+
+        int messageCount = 10;
+        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        TestUtil.sendEventsWithinTimeframe(expectedMessages, DEFAULT_MESSAGE_WAIT);
+        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+                conn,
+                messageCount,
+                DEFAULT_MESSAGE_WAIT,
+                TestUtil.QUEUE_NAME
+        );
+        assertEquals(expectedMessages, actualMessages);
+    }
+
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -94,6 +94,14 @@ public class ConnectionIntegrationTest {
     }
 
     /**
+     * Clean up outstanding messages before running new tests.
+     */
+    @Before
+    public void clearOutstandingConfirms() {
+        MQConnection.getInstance().clearOutstandingConfirms();
+    }
+
+    /**
      * Format a URI to toxiproxy, which will be forwarded to RabbitMQ.
      */
     private String formatProxyServerUri() {
@@ -133,6 +141,7 @@ public class ConnectionIntegrationTest {
                 TestUtil.QUEUE_NAME
         );
         assertEquals(expectedMessages, actualMessages);
+        assertEquals( 0, conn.getSizeOutstandingConfirms());
     }
 
     /**
@@ -156,6 +165,7 @@ public class ConnectionIntegrationTest {
                 DEFAULT_MESSAGE_WAIT,
                 TestUtil.QUEUE_NAME
         );
+        assertEquals( 0, conn.getSizeOutstandingConfirms());
         assertEquals(expectedMessages, actualMessages);
     }
 

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/TestUtil.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/TestUtil.java
@@ -1,0 +1,193 @@
+/**
+ The MIT License
+
+ Copyright 2020 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rabbitmq.client.AMQP;
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.DefaultConsumer;
+import com.rabbitmq.client.Envelope;
+import hudson.util.Secret;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.function.BooleanSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.AssumptionViolatedException;
+import org.testcontainers.containers.RabbitMQContainer;
+
+/**
+ * Utility methods for running e.g. integration tests and configuration setup.
+ *
+ * @author Hampus Johansson
+ */
+public final class TestUtil {
+
+    public static final String EXCHANGE = "jenkins";
+    public static final String QUEUE_NAME = "test-queue";
+    public static final int PORT = 5672;
+
+    private static RabbitMQContainer defaultMQContainer = null;
+
+    /**
+     * Creates a default RabbitMQ container to run tests against. It declares an Exchange (EXCHANGE)
+     * with a binding to a queue (QUEUE_NAME). No routing queue should be specified. The container may
+     * be started by, for example, using a jUnit @Rule.
+     *
+     * @return an RabbitMQ container singleton. A container is not started.
+     */
+    public static RabbitMQContainer getDefaultMQContainer() {
+        if (defaultMQContainer == null) {
+            defaultMQContainer = new RabbitMQContainer("rabbitmq:3-management")
+                    .withExposedPorts(PORT, 15672)
+                    .withExchange(EXCHANGE, "direct")
+                    .withQueue(QUEUE_NAME)
+                    .withBinding(EXCHANGE, QUEUE_NAME);
+        }
+        return defaultMQContainer;
+    }
+
+    /**
+     * Set common configuration values, intended for use together with the RabbitMQ container.
+     *
+     * @param config A configuration object to set default configuration for.
+     */
+    public static void setDefaultConfig(EiffelBroadcasterConfig config) {
+        config.setUserName("guest");
+        config.setUserPassword(Secret.fromString("guest"));
+        config.setExchangeName(EXCHANGE);
+        config.setRoutingKey("");
+        config.setVirtualHost(null);
+        config.setEnableBroadcaster(true);
+    }
+
+    /**
+     * Wait for x events on the queue to be published.
+     *
+     * @param conn A connection to be used for connecting to RabbitMQ
+     * @param numberExpectedEvents stop after finding this many events
+     * @param secondsWaitPerEvent the max time to wait for an event
+     * @param queueName the queue to listen to events on
+     *
+     * @return a list of the found EiffelEvent
+     */
+    public static ArrayList<EiffelEvent> waitForMessages(
+            MQConnection conn,
+            int numberExpectedEvents,
+            int secondsWaitPerEvent,
+            String queueName
+    ) throws IOException, InterruptedException {
+        Channel channel = conn.getConnection().openChannel().get();
+        LinkedBlockingQueue<EiffelEvent> foundMessages = new LinkedBlockingQueue<>();
+        ArrayList<EiffelEvent> foundMessagesArray = new ArrayList<>();
+
+        DefaultConsumer consumer = new DefaultConsumer(channel) {
+            ObjectMapper mapper = new ObjectMapper();
+
+            @Override
+            public void handleDelivery(
+                    String consumerTag,
+                    Envelope envelope,
+                    AMQP.BasicProperties properties,
+                    byte[] body) throws IOException {
+
+                foundMessages.offer(mapper.readValue(body, EiffelEvent.class));
+                synchronized (foundMessages) {
+                    foundMessages.notify();
+                }
+            }
+        };
+
+        channel.basicConsume(queueName, true, consumer);
+
+        synchronized (foundMessages) {
+            while(foundMessages.size() != numberExpectedEvents) {
+                foundMessages.wait(Duration.ofSeconds(secondsWaitPerEvent).toMillis());
+            }
+            foundMessages.drainTo(foundMessagesArray);
+        }
+        return foundMessagesArray;
+    }
+
+    /**
+     * Publish a list of events to RabbitMQ.
+     *
+     * @param events the events to be published to RabbitMQ
+     * @param waitTime the max time to wait for all events to be published
+     *
+     * @throws EventValidationFailedException if any event didn't pass the schema validation
+     * @throws InterruptedException if all events couldn't be published within the wait time
+     * @throws JsonProcessingException if there was an error serializing an event to JSON
+     * @throws SchemaUnavailableException if no schema was available for the event's type and version
+     */
+    public static void sendEventsWithinTimeframe(ArrayList<EiffelEvent> events, int waitTime)
+            throws EventValidationFailedException, InterruptedException, JsonProcessingException, SchemaUnavailableException {
+        for (EiffelEvent event : events) {
+            Util.mustPublishEvent(event);
+        }
+        if (!waitUntil(Duration.ofSeconds(waitTime), () -> MQConnection.getInstance().getSizeOutstandingConfirms() == 0)) {
+            throw new AssumptionViolatedException("All events could not be confirmed within the timeframe");
+        }
+    }
+
+    /**
+     * Creates a list of x events. Useful for generating messages during testing.
+     *
+     * @param count the number of events to create
+     *
+     * @return list of events
+     */
+    public static ArrayList<EiffelEvent> createEvents(int count) {
+        return IntStream.range(1, count + 1)
+                .mapToObj(i -> new EiffelArtifactCreatedEvent(String.format("pkg:test@%d", i)))
+                .collect(Collectors.toCollection(ArrayList::new));
+    }
+
+    /**
+     * Busy wait until a condition becomes true
+     *
+     * @param timeout a timeout not to wait longer than.
+     * @param condition a condition to evaluate. Proceed if condition is true
+     *
+     * @return the return value of the condition
+     * @throws InterruptedException if the sleep is interrupted
+     */
+    public static boolean waitUntil(Duration timeout, BooleanSupplier condition) throws InterruptedException {
+        int waited = 0;
+        while (!condition.getAsBoolean() && waited < timeout.toMillis()) {
+            Thread.sleep(100L);
+            waited += 100;
+        }
+        return condition.getAsBoolean();
+    }
+
+}


### PR DESCRIPTION
Improves the reliability and performance of message publishing in multiple ways, e.g. by introducing publisher confirms and asynchronous acks. Also adds integration tests for these operations using the testcontainers library.

This patch series is a reworked adaptation of what @hampusjohansson1 did in https://github.com/jenkinsci/mq-notifier-plugin/pull/30 and a few follow-up PRs. Fixup commits have been squashed into the original commits where the fixes belonged to make this series less noisy. Still, there are a few commits that change some things back and forth so reviewing the PR commit-by-commit might be more work. The resulting MQConnection.java (where nearly all the changes take place, except the new tests) is very close to the corresponding file in the MQ Notifier plugin. 

There are a couple of original commits by myself at the end.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
