### PR TITLE
Replace <tt> tags with <code> to make Javadoc generation work with Java 11

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
@@ -38,7 +38,7 @@ import org.kohsuke.stapler.StaplerRequest;
  * An {@link OptionalJobProperty} that can be used to populate additional members in
  * in the Eiffel activity events emitted for the builds of a job.
  * <p>
- * Also defines a <tt>eiffelActivity</tt> pipeline step that can be used to set
+ * Also defines a <code>eiffelActivity</code> pipeline step that can be used to set
  * the properties via pipeline code:
  * <pre>
  * properties([

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
@@ -67,11 +67,11 @@ public class EiffelArtifactPublisher {
      * Prepares a {@link EiffelArtifactPublishedEvent} that's ready to be sent.
      * @param creationEvent the {@link EiffelArtifactCreatedEvent} that should be published
      * @throws EmptyArtifactException when the {@link EiffelArtifactCreatedEvent} doesn't contain any files
-     *                                in <tt>data.fileInformation</tt>
+     *                                in <code>data.fileInformation</code>
      * @throws IOException when there was a problem correlating the files in the {@link EiffelArtifactCreatedEvent}
      *                     with the files in the {@link hudson.model.Run}'s artifacts
      * @throws MissingArtifactException when one or more of the files listed in
-     *                                  the {@link EiffelArtifactCreatedEvent}'s <tt>data.fileInformation</tt> array
+     *                                  the {@link EiffelArtifactCreatedEvent}'s <code>data.fileInformation</code> array
      *                                  doesn't exist in Jenkins's artifact directory
      * @throws URISyntaxException when an error occurred when trying to construct a URI to an artifact file
      */

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -96,7 +96,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
     private String appId;
     /* A list of strings representing categories to include in the ActTs. */
     private final List<String> activityCategories = new ArrayList<>();
-    /* How the hostname used in the <tt>meta.source.host</tt> member should be determined. */
+    /* How the hostname used in the <code>meta.source.host</code> member should be determined. */
     private HostnameSource hostnameSource = HostnameSource.NETWORK_STACK;
 
     private transient final EventValidator eventValidator = new EventValidator();

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/HostnameSource.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/HostnameSource.java
@@ -26,7 +26,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 /**
  * Describes how the hostname of the Jenkins controller should be determined. This hostname
- * is currently used to populate the <tt>meta.source.host</tt> member of all events.
+ * is currently used to populate the <code>meta.source.host</code> member of all events.
  */
 public enum HostnameSource {
     /** The hostname of the Jenkins controller according to the network stack */

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -46,7 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Provides Eiffel event source information (the <tt>meta.source</tt> member of all events)
+ * Provides Eiffel event source information (the <code>meta.source</code> member of all events)
  * for a Jenkins plugin.
  *
  * Computes values during initialization and reuses them for all subsequent events, except for

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
@@ -45,8 +45,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
- * A base class for Eiffel events that defines the common event attributes (<tt>meta</tt> and <tt>links</tt>)
- * and makes it easy for subclasses to add an event-specific <tt>data</tt> attribute.
+ * A base class for Eiffel events that defines the common event attributes (<code>meta</code> and <code>links</code>)
+ * and makes it easy for subclasses to add an event-specific <code>data</code> attribute.
  *
  * See the Eiffel event documentation for each concrete event type for more on the meaning of the attributes.
  */
@@ -413,7 +413,7 @@ public class EiffelEvent {
 
     /**
      * Deserializes a JSON payload into an instance of a subclass of {@link EiffelEvent} based on
-     * the payload's <tt>meta.type</tt> member.
+     * the payload's <code>meta.type</code> member.
      */
     static class Deserializer extends StdDeserializer<Object> {
         protected Deserializer() {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/GenericEiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/GenericEiffelEvent.java
@@ -35,7 +35,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A placeholder representation of an arbitrary Eiffel event that doesn't have a dedicated POJO class defined
- * in this package. This class behaves exactly like the specific classes except that the event's <tt>data</tt>
+ * in this package. This class behaves exactly like the specific classes except that the event's <code>data</code>
  * attribute is just saved as a {@link JsonNode}.
  */
 @JsonInclude(JsonInclude.Include.NON_EMPTY)

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/InvalidJsonPayloadException.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/InvalidJsonPayloadException.java
@@ -27,7 +27,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 /**
- * Thrown when the JSON representation of an Eiffel event lacks an <tt>meta.type</tt> member that
+ * Thrown when the JSON representation of an Eiffel event lacks an <code>meta.type</code> member that
  * determines the event type.
  */
 public class InvalidJsonPayloadException extends JsonProcessingException {


### PR DESCRIPTION
Java 11 no longer supports `<tt>` tags in the Javadoc code, and we'd used that tag in several places. Unfortunately the CI job doesn't attempt to generate the Javadoc so this wasn't discovered in #92 where we switched to Java 11.

### Testing done
Previously `mvn javadoc:javadoc` didn't pass (including when it was run implicitly by `mvn release:perform`) but now it does.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
