### PR TITLE
Introduce pluggable routing keys and Sepia conformance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <scope>test</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/FixedRoutingKeyProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/FixedRoutingKeyProvider.java
@@ -1,0 +1,88 @@
+/**
+ The MIT License
+
+ Copyright 2023 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * A {@link RoutingKeyProvider} implementation that always produces
+ * the same configurable fixed string regardless of the event input.
+ */
+public class FixedRoutingKeyProvider extends RoutingKeyProvider {
+    @NonNull
+    private String fixedRoutingKey;
+
+    @DataBoundConstructor
+    public FixedRoutingKeyProvider(@NonNull String fixedRoutingKey) {
+        this.fixedRoutingKey = fixedRoutingKey;
+    }
+
+    /** {@inheritDoc} */
+    @NonNull
+    @Override
+    public String getRoutingKey(final EiffelEvent event) {
+        return getFixedRoutingKey();
+    }
+
+    @NonNull
+    public String getFixedRoutingKey() {
+        return fixedRoutingKey;
+    }
+
+    @DataBoundSetter
+    public void setFixedRoutingKey(@NonNull String fixedRoutingKey) {
+        this.fixedRoutingKey = fixedRoutingKey;
+    }
+
+    @Override
+    public Descriptor<RoutingKeyProvider> getDescriptor() {
+        return Jenkins.get().getDescriptorByType(FixedRoutingKeyProvider.FixedRoutingKeyProviderDescriptor.class);
+    }
+
+    /** Descriptor for {@link FixedRoutingKeyProvider}. */
+    @Extension
+    public static class FixedRoutingKeyProviderDescriptor extends RoutingKeyProviderDescriptor {
+        public FormValidation doCheckFixedRoutingKey(@QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.error("The routing key must be a non-empty string.");
+            }
+            return FormValidation.ok();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Fixed string";
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/RoutingKeyProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/RoutingKeyProvider.java
@@ -1,0 +1,56 @@
+/**
+ The MIT License
+
+ Copyright 2023 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import hudson.ExtensionList;
+import hudson.model.Describable;
+import hudson.model.Descriptor;
+import java.io.Serializable;
+import jenkins.model.Jenkins;
+
+/**
+ * A routing key provider computes the AMQP routing key that should be used when publishing
+ * a given {@link EiffelEvent}.
+ */
+public abstract class RoutingKeyProvider implements Describable<RoutingKeyProvider>, Serializable {
+    /**
+     * Computes the routing key for an event.
+     *
+     * @param event the {@link EiffelEvent} whose routing key is wanted
+     * @return a string consisting of one or more dot-separated tokens that's usable as a routing key
+     */
+    public abstract String getRoutingKey(final EiffelEvent event);
+
+    /**
+     * Descriptor for {@link RoutingKeyProvider}s.
+     */
+    public abstract static class RoutingKeyProviderDescriptor extends Descriptor<RoutingKeyProvider> {
+        /** Obtain all registered {@link RoutingKeyProviderDescriptor}s. */
+        public static ExtensionList<RoutingKeyProviderDescriptor> all() {
+            return Jenkins.get().getExtensionList(RoutingKeyProviderDescriptor.class);
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProvider.java
@@ -1,0 +1,93 @@
+/**
+ The MIT License
+
+ Copyright 2023 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+/**
+ * A routing key provider that produces AMQP routing keys that adhere to
+ * the <a href="https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html">message
+ * broker requirements in Sepia</a> (Sepia Eiffel Protocol Implementation Architecture).
+ */
+public class SepiaRoutingKeyProvider extends RoutingKeyProvider {
+    private String tag;
+
+    @DataBoundConstructor
+    public SepiaRoutingKeyProvider() { }
+
+    /** {@inheritDoc} */
+    @NonNull
+    @Override
+    public String getRoutingKey(final EiffelEvent event) {
+        return String.format("eiffel._.%s.%s.%s",
+                event.getMeta().getType(),
+                getRoutingKeyToken(getTag()),
+                getRoutingKeyToken(event.getMeta().getSource().getDomainId()));
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    @DataBoundSetter
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    @Override
+    public Descriptor<RoutingKeyProvider> getDescriptor() {
+        return Jenkins.get().getDescriptorByType(SepiaRoutingKeyProviderDescriptor.class);
+    }
+
+    private String getRoutingKeyToken(String value) {
+        return StringUtils.isBlank(value) ? "_" : value;
+    }
+
+    /** Descriptor for {@link SepiaRoutingKeyProvider}. */
+    @Extension
+    public static class SepiaRoutingKeyProviderDescriptor extends RoutingKeyProviderDescriptor {
+        public FormValidation doCheckTag(@QueryParameter String value) {
+            if (value.contains(".")) {
+                return FormValidation.error("The tag must not contain any dots since that would "
+                        + "make the resulting routing key ambiguous.");
+            }
+            return FormValidation.ok();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Sepia";
+        }
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderConfigurator.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderConfigurator.java
@@ -1,0 +1,90 @@
+/**
+ The MIT License
+
+ Copyright 2023 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
+
+import edu.umd.cs.findbugs.annotations.CheckForNull;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.Extension;
+import io.jenkins.plugins.casc.BaseConfigurator;
+import io.jenkins.plugins.casc.ConfigurationContext;
+import io.jenkins.plugins.casc.Configurator;
+import io.jenkins.plugins.casc.ConfiguratorException;
+import io.jenkins.plugins.casc.model.CNode;
+import io.jenkins.plugins.casc.model.Mapping;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.lang.StringUtils;
+
+/**
+ * A {@link Configurator} implementation that takes care of CasC serialization/deserialization
+ * of {@link SepiaRoutingKeyProvider} objects. CasC tries very hard to not serialize any default
+ * values or empty objects, so unless you've set the optional Tag field to a non-empty value it
+ * won't serialize the SepiaRoutingKeyProvider object at all, causing us to lose information about
+ * which class was chosen as the routing key provider. This configurator works around this by
+ * always adding a dummy key/value pair during serialization.
+ */
+@Extension(optional = true)
+public class SepiaRoutingKeyProviderConfigurator extends BaseConfigurator<SepiaRoutingKeyProvider> {
+    /** The name of the configuration key used for {@link SepiaRoutingKeyProvider#getTag()}. */
+    private static final String KEY_TAG = "tag";
+
+    /** The name of the configuration key used for the dummy value used to avoid optimization. */
+    private static final String KEY_DUMMY = "dummy";
+
+    @Override
+    protected SepiaRoutingKeyProvider instance(Mapping mapping, ConfigurationContext context) throws ConfiguratorException {
+        SepiaRoutingKeyProvider provider = new SepiaRoutingKeyProvider();
+        if (mapping == null) {
+            return provider;
+        }
+        provider.setTag(mapping.get(KEY_TAG) != null ? mapping.getScalarValue(KEY_TAG) : "");
+        return provider;
+    }
+
+    @Override
+    public boolean canConfigure(Class clazz) {
+        return clazz == SepiaRoutingKeyProvider.class;
+    }
+
+    @CheckForNull
+    @Override
+    public CNode describe(SepiaRoutingKeyProvider instance, ConfigurationContext context) throws Exception {
+        Mapping mapping = new Mapping();
+        mapping.put(KEY_DUMMY, "dummy value to make JCasC behave the way we want");
+        mapping.put(KEY_TAG, StringUtils.defaultIfBlank(instance.getTag(), ""));
+        return mapping;
+    }
+
+    @Override
+    public Class<SepiaRoutingKeyProvider> getTarget() {
+        return SepiaRoutingKeyProvider.class;
+    }
+
+    @NonNull
+    @Override
+    public List<Configurator<SepiaRoutingKeyProvider>> getConfigurators(ConfigurationContext context) {
+        return Collections.singletonList(this);
+    }
+}

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig/config.groovy
@@ -50,10 +50,9 @@ f.section(title: "Eiffel Broadcaster Plugin") {
     f.entry(title: "Virtual host", field: "virtualHost", help: l+"help-virtual-host.html") {
         f.textbox("value":instance.virtualHost)
     }
-    f.entry(title: "Routing Key", field: "routingKey", help: l+"help-routing-key.html") {
-        f.textbox("value":instance.routingKey)
-    }
     f.advanced() {
+        f.dropdownDescriptorSelector(title: "Routing key algorithm",
+                field: "routingKeyProvider", descriptors: descriptor.routingKeyProviderDescriptors)
         f.entry(title: "Application Id", field: "appId", help: l+"help-application-id.html") {
             f.textbox("value":instance.appId)
         }

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/FixedRoutingKeyProvider/config.jelly
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/FixedRoutingKeyProvider/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright 2023 Axis Communications AB.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Routing key"
+             help="/plugin/eiffel-broadcaster/FixedRoutingKeyProvider/help-fixed-routing-key.html">
+        <f:textbox field="fixedRoutingKey"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProvider/config.jelly
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProvider/config.jelly
@@ -1,0 +1,30 @@
+<!--
+The MIT License
+
+Copyright 2023 Axis Communications AB.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="Tag"
+             help="/plugin/eiffel-broadcaster/SepiaRoutingKeyProvider/help-tag.html">
+        <f:textbox field="tag"/>
+    </f:entry>
+</j:jelly>

--- a/src/main/webapp/FixedRoutingKeyProvider/help-fixed-routing-key.html
+++ b/src/main/webapp/FixedRoutingKeyProvider/help-fixed-routing-key.html
@@ -1,0 +1,3 @@
+<div>
+    The string that should be used as the routing key for all outbound events.
+</div>

--- a/src/main/webapp/SepiaRoutingKeyProvider/help-tag.html
+++ b/src/main/webapp/SepiaRoutingKeyProvider/help-tag.html
@@ -1,0 +1,8 @@
+<div>
+    The tag is an implementation-defined string that will be included as
+    the second to last token in the routing key (see the
+    <a href="https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html">
+        Sepia recommendation
+    </a>). The string should not include any periods (".") but can otherwise
+    contain any set of characters acceptable in an AMQP routing key.
+</div>

--- a/src/main/webapp/help-routing-key-provider.html
+++ b/src/main/webapp/help-routing-key-provider.html
@@ -1,0 +1,18 @@
+<div>
+    The algorithm used to generate routing keys for outbound events.
+    <ul>
+        <li>
+            <b>Sepia</b>. The routing keys will follow the
+            <a href="https://eiffel-community.github.io/eiffel-sepia/rabbitmq-message-broker.html">Sepia recommendation</a>,
+            resulting in routing keys like e.g. <code>eiffel._.EiffelArtifactCreatedEvent._._</code>.
+            This is the default for new configurations.
+        </li>
+        <li>
+            <b>Fixed string</b>. The routing key will always be the configured string.
+        </li>
+    </ul>
+    Other plugins may provide additional algorithms by extending
+    <a href="https://javadoc.jenkins.io/plugin/eiffel-broadcaster/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/RoutingKeyProvider.html">
+        RoutingKeyProvider
+    </a>.
+</div>

--- a/src/main/webapp/help-routing-key.html
+++ b/src/main/webapp/help-routing-key.html
@@ -1,3 +1,0 @@
-<div>
-    Your MQ routing key to use.
-</div>

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
@@ -1,0 +1,57 @@
+/**
+ The MIT License
+
+ Copyright 2023 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
+
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+public class SepiaRoutingKeyProviderTest {
+    @Test
+    public void testGetRoutingKey_UsesUnderscoreInsteadOfNull() {
+        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
+        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._._"));
+    }
+
+    @Test
+    public void testGetRoutingKey_UsesDomainIdIfSet() {
+        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
+        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        event.getMeta().getSource().setDomainId("some-domainid");
+        assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._.some-domainid"));
+    }
+
+    @Test
+    public void testGetRoutingKey_UsesTagIfSet() {
+        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
+        rp.setTag("some-tag");
+        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent.some-tag._"));
+    }
+}

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-expected-output.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-expected-output.yml
@@ -3,7 +3,9 @@ enableBroadcaster: true
 exchangeName: "eiffel-exchange"
 hostnameSource: CONFIGURED_URL
 persistentDelivery: false
-routingKey: "random-routing-key"
+routingKeyProvider:
+  sepia:
+    tag: "random-tag"
 serverUri: "amqp://rabbitmq.example.com"
 userName: "johndoe"
 virtualHost: "/"

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-fixed-routing-key-provider.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-fixed-routing-key-provider.yml
@@ -1,0 +1,14 @@
+unclassified:
+  eiffel-broadcaster:
+    appId: "random-appid"
+    enableBroadcaster: true
+    exchangeName: "eiffel-exchange"
+    hostnameSource: CONFIGURED_URL
+    persistentDelivery: false
+    routingKeyProvider:
+      fixed:
+        fixedRoutingKey: "random-routing-key"
+    serverUri: "amqp://rabbitmq.example.com"
+    userName: "johndoe"
+    userPassword: "{AQAAABAAAAAQamrmPWJHqDjtHxMg0DLrGcCR/HrxsVE6BbBGft31t5g=}"
+    virtualHost: "/"

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-legacy-routing-key.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-legacy-routing-key.yml
@@ -5,7 +5,7 @@ unclassified:
     exchangeName: "eiffel-exchange"
     hostnameSource: CONFIGURED_URL
     persistentDelivery: false
-    routingKey: "random-routing-key"
+    routingKey: "random-legacy-key"
     serverUri: "amqp://rabbitmq.example.com"
     userName: "johndoe"
     userPassword: "{AQAAABAAAAAQamrmPWJHqDjtHxMg0DLrGcCR/HrxsVE6BbBGft31t5g=}"

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-sepia-routing-key-provider.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-with-sepia-routing-key-provider.yml
@@ -1,0 +1,14 @@
+unclassified:
+  eiffel-broadcaster:
+    appId: "random-appid"
+    enableBroadcaster: true
+    exchangeName: "eiffel-exchange"
+    hostnameSource: CONFIGURED_URL
+    persistentDelivery: false
+    routingKeyProvider:
+      sepia:
+        tag: "random-tag"
+    serverUri: "amqp://rabbitmq.example.com"
+    userName: "johndoe"
+    userPassword: "{AQAAABAAAAAQamrmPWJHqDjtHxMg0DLrGcCR/HrxsVE6BbBGft31t5g=}"
+    virtualHost: "/"

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-without-routing-key-provider.yml
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/jcasc-input-without-routing-key-provider.yml
@@ -1,0 +1,11 @@
+unclassified:
+  eiffel-broadcaster:
+    appId: "random-appid"
+    enableBroadcaster: true
+    exchangeName: "eiffel-exchange"
+    hostnameSource: CONFIGURED_URL
+    persistentDelivery: false
+    serverUri: "amqp://rabbitmq.example.com"
+    userName: "johndoe"
+    userPassword: "{AQAAABAAAAAQamrmPWJHqDjtHxMg0DLrGcCR/HrxsVE6BbBGft31t5g=}"
+    virtualHost: "/"


### PR DESCRIPTION
Having all events sent with the same fixed routing key can force consumers to consume more than they want to. Since a few years, Sepia contains a recommended routing key format that we should be able to conform to.

To ensure a smooth migration path for everyone, we replace the EiffelBroadcasterConfig#routingKey string field with a new #routingKeyProvider attribute that contains a subclass of RoutingKeyProvider. We ship the plugin with two such implementations; FixedRoutingKeyProvider that's equivalent to the legacy behavior, and SepiaRoutingKeyProvider that follows Sepia. Old Jenkins instances will get migrated to FixedRoutingKeyProvider while new ones get SepiaRoutingKeyProvider by default. Other plugins may supply their own implementations.

Fixes #69

### Testing done

Manual tests of the functionality. Updated and added relevant automated tests.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
