### PR TITLE
Correct bad Javadoc syntax that prevented 2.7.0 release

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -279,7 +279,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
 
     /**
      * Sets the routing key. This method exists for backwards compatibility reasons.
-     * Any non-null value will be passed to {@see #setRoutingKeyProvider(RoutingKeyProvider)}
+     * Any non-null value will be passed to {@link #setRoutingKeyProvider(RoutingKeyProvider)}
      * and this setter's underlying attribute will be set to null.
      *
      * @param routingKey the routing key.


### PR DESCRIPTION
Commit bcc78f2 mistakenly introduced a Javadoc markup bug (`@see` was used instead of `@link`) which wasn't discovered until Javadoc was run during the release process for 2.7.0.

We should run "mvn javadoc:javadoc" during the pre-merge CI execution but we're inheriting its configuration so it's not immediately clear how to accomplish this.

### Testing done

Verified that `mvn javadoc:javadoc` passes with this correction (but not without it). It's a minor change in the Javadoc markup so I haven't tested anything else.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
