### PR TITLE
Use local variable type inference where possible

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelActivityJobProperty.java
@@ -75,7 +75,7 @@ public class EiffelActivityJobProperty extends OptionalJobProperty<Job<?, ?>> {
         public OptionalJobProperty newInstance(StaplerRequest req, JSONObject formData) throws FormException {
             // The form uses a textarea for the categories but we split out the lines and store
             // them individually in a list so we need to override the Stapler's default behavior.
-            List<String> categories = Util.getLinesInString(formData.getString("categories"));
+            var categories = Util.getLinesInString(formData.getString("categories"));
             return new EiffelActivityJobProperty(categories);
         }
     }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
@@ -32,8 +32,6 @@ import hudson.Functions;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.List;
-import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 import jenkins.util.VirtualFile;
@@ -85,11 +83,11 @@ public class EiffelArtifactPublisher {
 
         // Before creating an ArtP event, verify that all files specified in the ArtC (data.fileInformation)
         // actually exist as Jenkins artifacts for the Run in question.
-        SortedSet<String> missingArtifacts = new TreeSet<>();
-        List<String> artifactFilenames = creationEvent.getData().getFileInformation().stream()
+        var missingArtifacts = new TreeSet<String>();
+        var artifactFilenames = creationEvent.getData().getFileInformation().stream()
                 .map(EiffelArtifactCreatedEvent.Data.FileInformation::getName)
                 .collect(Collectors.toList());
-        for (String filename : artifactFilenames) {
+        for (var filename : artifactFilenames) {
             if (!artifactRoot.child(filename).isFile() ) {
                 missingArtifacts.add(filename);
             }
@@ -99,11 +97,11 @@ public class EiffelArtifactPublisher {
         }
 
         // Sanity check okay, continue with the construction of the ArtP event.
-        EiffelArtifactPublishedEvent publishEvent = new EiffelArtifactPublishedEvent(creationEvent.getMeta().getId());
+        var publishEvent = new EiffelArtifactPublishedEvent(creationEvent.getMeta().getId());
         publishEvent.getLinks().add(
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, contextEvent.getMeta().getId()));
-        for (EiffelArtifactCreatedEvent.Data.FileInformation fileInfo : creationEvent.getData().getFileInformation()) {
-            EiffelArtifactPublishedEvent.Data.Location location = new EiffelArtifactPublishedEvent.Data.Location(
+        for (var fileInfo : creationEvent.getData().getFileInformation()) {
+            var location = new EiffelArtifactPublishedEvent.Data.Location(
                     EiffelArtifactPublishedEvent.Data.Location.Type.PLAIN,
                     new URI(Functions.joinPath(runURI.toString(), "artifact", fileInfo.getName())));
             location.setName(fileInfo.getName());

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -438,7 +438,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
 
     public ListBoxModel doFillSystemSigningCredentialsIdItems(@AncestorInPath Item item,
                                                               @QueryParameter String credentialsId) {
-        StandardListBoxModel result = new StandardListBoxModel();
+        var result = new StandardListBoxModel();
         if (item == null) {
             if (!Jenkins.get().hasPermission(Jenkins.ADMINISTER)) {
                 return result.includeCurrentValue(credentialsId);
@@ -473,12 +473,12 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
                                            @QueryParameter(USERNAME) final String name,
                                            @QueryParameter(PASSWORD) final Secret pw) throws ServletException {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
-        UrlValidator urlValidator = new UrlValidator(ALLOWED_URL_SCHEMES, UrlValidator.ALLOW_LOCAL_URLS);
-        FormValidation result = FormValidation.ok();
+        var urlValidator = new UrlValidator(ALLOWED_URL_SCHEMES, UrlValidator.ALLOW_LOCAL_URLS);
+        var result = FormValidation.ok();
         if (urlValidator.isValid(uri)) {
             Connection conn = null;
             try {
-                ConnectionFactory connFactory = new ConnectionFactory();
+                var connFactory = new ConnectionFactory();
                 connFactory.setUri(uri);
                 if (StringUtils.isNotEmpty(name)) {
                     connFactory.setUsername(name);

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributor.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributor.java
@@ -62,14 +62,14 @@ public class EiffelEnvironmentContributor extends EnvironmentContributor {
     @Override
     public void buildEnvironmentFor(@NonNull Run r, @NonNull EnvVars envs, @NonNull TaskListener listener)
             throws IOException, InterruptedException {
-        EiffelActivityAction action = r.getAction(EiffelActivityAction.class);
+        var action = r.getAction(EiffelActivityAction.class);
         if (action != null) {
             envs.put(EiffelEnvironmentContributor.ACTIVITY_TRIGGERED, action.getTriggerEventJSON());
-            String startedEvent = action.getStartedEventJSON();
+            var startedEvent = action.getStartedEventJSON();
             if (startedEvent != null) {
                 envs.put(EiffelEnvironmentContributor.ACTIVITY_STARTED, startedEvent);
             }
-            String finishedEvent = action.getFinishedEventJSON();
+            var finishedEvent = action.getFinishedEventJSON();
             if (finishedEvent != null) {
                 envs.put(EiffelEnvironmentContributor.ACTIVITY_FINISHED, finishedEvent);
             }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ItemListenerImpl.java
@@ -50,7 +50,7 @@ public class ItemListenerImpl extends ItemListener {
     @Override
     public final void onLoaded() {
         logger.info("All jobs have been loaded.");
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         if (config != null && config.getEnableBroadcaster()) {
             MQConnection.getInstance().initialize(config.getUserName(), config.getUserPassword(),
                     config.getServerUri(), config.getVirtualHost());

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProvider.java
@@ -31,7 +31,6 @@ import com.github.packageurl.PackageURL;
 import com.github.packageurl.PackageURLBuilder;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import hudson.PluginWrapper;
 import java.net.InetAddress;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -69,10 +68,10 @@ public class JenkinsSourceProvider implements SourceProvider {
     private URI uri;
 
     public JenkinsSourceProvider() {
-        Jenkins jenkins = Jenkins.getInstanceOrNull();
+        var jenkins = Jenkins.getInstanceOrNull();
         if (jenkins != null) {
-            String pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
-            PluginWrapper pluginWrapper = jenkins.getPluginManager().getPlugin(pluginShortName);
+            var pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
+            var pluginWrapper = jenkins.getPluginManager().getPlugin(pluginShortName);
             if (pluginWrapper != null) {
                 name = pluginWrapper.getDisplayName();
 
@@ -124,7 +123,7 @@ public class JenkinsSourceProvider implements SourceProvider {
      */
     @CheckForNull
     private synchronized String getHost() {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         if (config == null) {
             return null;
         }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/MQConnection.java
@@ -200,7 +200,7 @@ public final class MQConnection implements ShutdownListener {
      */
     public void addMessageToQueue(String exchange, String routingKey, AMQP.BasicProperties props, byte[] body) {
         startMessageQueueThread();
-        MessageData messageData = new MessageData(exchange, routingKey, props, body);
+        var messageData = new MessageData(exchange, routingKey, props, body);
         if (!messageQueue.offer(messageData)) {
             logger.error("addMessageToQueue() failed, internal RabbitMQ queue is full!");
         }
@@ -219,8 +219,7 @@ public final class MQConnection implements ShutdownListener {
                     channel.confirmSelect();
                     addMessageConfirmListener(channel);
                 }
-                MessageData messageData = (MessageData)messageQueue.poll(SENDMESSAGE_TIMEOUT,
-                                                                         TimeUnit.MILLISECONDS);
+                var messageData = (MessageData)messageQueue.poll(SENDMESSAGE_TIMEOUT, TimeUnit.MILLISECONDS);
                 if (messageData != null) {
                     validateExchange(channel, messageData.getExchange());
                     getInstance().sendOnChannel(messageData, channel);
@@ -293,7 +292,7 @@ public final class MQConnection implements ShutdownListener {
 
         // Signature is addConfirmListener(successCallback, errorCallback)
         channel.addConfirmListener(cleanOutstandingConfirms, (sequenceNumber, multiple) -> {
-            MessageData message = outstandingConfirms.get(sequenceNumber);
+            var message = outstandingConfirms.get(sequenceNumber);
             messageQueue.offer(message);
             cleanOutstandingConfirms.handle(sequenceNumber, multiple);
         });

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/RunListenerImpl.java
@@ -28,12 +28,9 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityFi
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityStartedEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import hudson.Extension;
-import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.model.listeners.RunListener;
-import java.net.URI;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,18 +61,18 @@ public class RunListenerImpl extends RunListener<Run> {
 
     @Override
     public void onStarted(Run r, TaskListener listener) {
-        UUID targetEvent = EiffelJobTable.getInstance().getAndClearEventTrigger(r.getQueueId());
+        var targetEvent = EiffelJobTable.getInstance().getAndClearEventTrigger(r.getQueueId());
         if (targetEvent == null) {
             logger.warn("The newly started {} could not be mapped to an emitted ActT event", r);
             return;
         }
-        EiffelActivityStartedEvent event = new EiffelActivityStartedEvent(targetEvent);
+        var event = new EiffelActivityStartedEvent(targetEvent);
 
-        URI runUri = Util.getRunUri(r);
+        var runUri = Util.getRunUri(r);
         if (runUri != null) {
             event.getData().setExecutionUri(runUri);
         }
-        URI logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
+        var logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
         if (logUri != null) {
             event.getData().getLiveLogs().add(
                     new EiffelActivityStartedEvent.Data.LiveLogs(CONSOLE_LOG_NAME, logUri));
@@ -92,14 +89,13 @@ public class RunListenerImpl extends RunListener<Run> {
 
     @Override
     public void onCompleted(Run r, TaskListener listener) {
-        Result res = r.getResult();
-        EiffelActivityFinishedEvent.Data.Outcome.Conclusion conclusion =
-                EiffelActivityFinishedEvent.Data.Outcome.Conclusion.INCONCLUSIVE;
+        var res = r.getResult();
+        var conclusion = EiffelActivityFinishedEvent.Data.Outcome.Conclusion.INCONCLUSIVE;
         if (res != null) {
             conclusion = Util.translateStatus(res.toString());
         }
 
-        EiffelActivityAction activityAction = r.getAction(EiffelActivityAction.class);
+        var activityAction = r.getAction(EiffelActivityAction.class);
         if (activityAction == null) {
             logger.warn("Unable to locate {} for {}, skipping sending of ActF event",
                     EiffelActivityAction.class.getSimpleName(), r);
@@ -116,7 +112,7 @@ public class RunListenerImpl extends RunListener<Run> {
             return;
         }
 
-        URI logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
+        var logUri = Util.getRunUri(r, CONSOLE_URI_PATH);
         if (logUri != null) {
             event.getData().getPersistentLogs().add(
                     new EiffelActivityFinishedEvent.Data.PersistentLogs(CONSOLE_LOG_NAME, logUri));

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/SigningKeyCache.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/SigningKeyCache.java
@@ -35,7 +35,6 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
 import java.security.UnrecoverableKeyException;
-import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
 import java.time.Duration;
 import java.time.Instant;
@@ -76,7 +75,7 @@ public class SigningKeyCache {
     public synchronized @NonNull Item get(@NonNull final String credentialsId)
             throws InvalidCertificateConfigurationException, KeyStoreException, NoSuchAlgorithmException,
             UnrecoverableKeyException {
-        Item cachedItem = cache.get(credentialsId);
+        var cachedItem = cache.get(credentialsId);
         if (cachedItem != null && !cachedItem.hasExpired()) {
             return cachedItem;
         }
@@ -84,7 +83,7 @@ public class SigningKeyCache {
         if (StringUtils.isEmpty(credentialsId)) {
             throw new InvalidCertificateConfigurationException("No certificate credential has been configured.");
         }
-        StandardCertificateCredentials cred = CredentialsMatchers.firstOrNull(
+        var cred = CredentialsMatchers.firstOrNull(
                 CredentialsProvider.lookupCredentials(
                         StandardCertificateCredentials.class, (ItemGroup) null, null, List.of()),
                 CredentialsMatchers.allOf(CredentialsMatchers.withId(credentialsId)));
@@ -92,7 +91,7 @@ public class SigningKeyCache {
             throw new InvalidCertificateConfigurationException(String.format(
                     "No certificate credential with the id \"%s\" was found.", credentialsId));
         }
-        Item newCacheItem = new Item(cred);
+        var newCacheItem = new Item(cred);
         cache.put(credentialsId, newCacheItem);
         return newCacheItem;
     }
@@ -132,17 +131,17 @@ public class SigningKeyCache {
 
             // Extract the first private key in the key store, then extract
             // the subject DN from the certificate associated with that key.
-            KeyStore keyStore = cred.getKeyStore();
+            var keyStore = cred.getKeyStore();
             if (!keyStore.aliases().hasMoreElements()) {
                 throw new InvalidCertificateConfigurationException("The keystore in the credential object was empty.");
             }
-            String alias = keyStore.aliases().nextElement();
+            var alias = keyStore.aliases().nextElement();
             if (keyStore.isKeyEntry(alias)) {
                 key = (PrivateKey) keyStore.getKey(alias, cred.getPassword().getPlainText().toCharArray());
             }
-            Certificate[] certificateChain = keyStore.getCertificateChain(alias);
+            var certificateChain = keyStore.getCertificateChain(alias);
             if (certificateChain != null && certificateChain.length > 0) {
-                Certificate certificate = certificateChain[0];
+                var certificate = certificateChain[0];
                 if (certificate instanceof X509Certificate) {
                     identity = ((X509Certificate) certificate).getSubjectX500Principal().getName();
                 }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Util.java
@@ -105,10 +105,10 @@ public final class Util {
      * @return the URI asked for, or null if a URI couldn't be resolved
      */
     public static URI getRunUri(final Run r, String... pathSuffix) {
-        Jenkins jenkins = Jenkins.get();
+        var jenkins = Jenkins.get();
         if (jenkins.getRootUrl() != null) {
             try {
-                String uri = Functions.joinPath(jenkins.getRootUrl(), r.getUrl());
+                var uri = Functions.joinPath(jenkins.getRootUrl(), r.getUrl());
                 if (pathSuffix.length == 0) {
                     return new URI(uri);
                 }
@@ -145,19 +145,19 @@ public final class Util {
             throws EventValidationFailedException, InvalidCertificateConfigurationException, InvalidKeyException,
             JsonCanonicalizationException, JsonProcessingException, KeyStoreException, NoSuchAlgorithmException,
             SchemaUnavailableException, SignatureException, UnsupportedAlgorithmException, UnrecoverableKeyException {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         if (config == null || !config.getEnableBroadcaster()) {
             return null;
         }
 
         if (allowSystemSignature && config.isSystemSigningEnabled()) {
-            SigningKeyCache.Item sigData = SigningKeyCache.getInstance().get(config.getSystemSigningCredentialsId());
+            var sigData = SigningKeyCache.getInstance().get(config.getSystemSigningCredentialsId());
             event.sign(sigData.getKey(), sigData.getIdentity(), config.getSystemSigningHashAlg());
         }
 
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode eventJson = mapper.valueToTree(event);
-        AMQP.BasicProperties props = new AMQP.BasicProperties.Builder()
+        var mapper = new ObjectMapper();
+        var eventJson = mapper.valueToTree(event);
+        var props = new AMQP.BasicProperties.Builder()
                 .appId(config.getAppId())
                 .deliveryMode(config.getPersistentDelivery() ? PERSISTENT_DELIVERY : NON_PERSISTENT_DELIVERY)
                 .contentType("application/json")
@@ -199,9 +199,9 @@ public final class Util {
      * @param s the line to split
      */
     public static List<String> getLinesInString(String s) {
-        List<String> result = new ArrayList<>();
-        for (String line : s.split("\\R")) {  // \R is "any Unicode linebreak sequence"
-            String trimmed = line.trim();
+        var result = new ArrayList<String>();
+        for (var line : s.split("\\R")) {  // \R is "any Unicode linebreak sequence"
+            var trimmed = line.trim();
             if (!trimmed.isEmpty()) {
                 result.add(trimmed);
             }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEvent.java
@@ -30,7 +30,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -96,15 +95,15 @@ public class EiffelEvent {
             UnsupportedAlgorithmException {
         // Prepare the event for signing by initializing the meta.security fields,
         // including an empty signature string.
-        EiffelEvent.Meta.Security.IntegrityProtection.Alg alg = getAlgorithm(key.getAlgorithm(), hashAlg);
-        EiffelEvent.Meta.Security sec = new EiffelEvent.Meta.Security(identity);
+        var alg = getAlgorithm(key.getAlgorithm(), hashAlg);
+        var sec = new EiffelEvent.Meta.Security(identity);
         sec.setIntegrityProtection(new EiffelEvent.Meta.Security.IntegrityProtection("", alg));
         getMeta().setSecurity(sec);
 
         // Serialize the event to canonical JSON form, compute the signature,
         // and update the signature field with the Base64-encoded signature.
-        ObjectMapper mapper = new ObjectMapper();
-        Signature sig = Signature.getInstance(alg.getSignatureAlgorithm());
+        var mapper = new ObjectMapper();
+        var sig = Signature.getInstance(alg.getSignatureAlgorithm());
         sig.initSign(key);
         try {
             sig.update(new JsonCanonicalizer(
@@ -738,15 +737,15 @@ public class EiffelEvent {
 
         @Override
         public Object deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
-            TreeNode node = p.readValueAsTree();
+            var node = p.readValueAsTree();
 
             // Obtain event type from the meta.type member.
-            TreeNode typeNode = node.path("meta").path("type");
+            var typeNode = node.path("meta").path("type");
             if (typeNode.isMissingNode()) {
                 throw new InvalidJsonPayloadException(
                         "Unable to figure out type of Eiffel event: no 'meta.type' key found");
             }
-            String eventType = p.getCodec().treeToValue(typeNode, String.class);
+            var eventType = p.getCodec().treeToValue(typeNode, String.class);
 
             // Attempt to deserialize the TreeNode into a class in this package
             // with the same name as the event type. If that fails, deserialize

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidator.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidator.java
@@ -29,11 +29,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.SpecVersion;
-import com.networknt.schema.ValidationMessage;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.io.InputStream;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -60,10 +57,10 @@ public class EventValidator {
      */
     public void validate(String eventName, String eventVersion, @NonNull final JsonNode eventJson)
             throws EventValidationFailedException, SchemaUnavailableException {
-        EventVersionKey key = new EventVersionKey(eventName, eventVersion);
-        JsonSchema schema = schemaCache.get(key);
+        var key = new EventVersionKey(eventName, eventVersion);
+        var schema = schemaCache.get(key);
         if (schema == null) {
-            try (InputStream schemaStream = schemaProvider.getSchema(eventName, eventVersion)) {
+            try (var schemaStream = schemaProvider.getSchema(eventName, eventVersion)) {
                 if (schemaStream == null) {
                     throw new SchemaUnavailableException(
                             String.format("Unable to locate a schema for %s@%s", eventName, eventVersion));
@@ -75,7 +72,7 @@ public class EventValidator {
             }
             schemaCache.put(key, schema);
         }
-        Set<ValidationMessage> result = schema.validate(eventJson);
+        var result = schema.validate(eventJson);
         if (!result.isEmpty()) {
             throw new EventValidationFailedException(result, eventJson);
         }

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStep.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStep.java
@@ -137,7 +137,7 @@ public class CreatePackageURLStep extends Step {
                     .withName(step.getName())
                     .withVersion(step.getVersion())
                     .withSubpath(step.getSubpath());
-            for (Map.Entry<String, String> entry : step.getQualifiers().entrySet()) {
+            for (var entry : step.getQualifiers().entrySet()) {
                 purlBuilder.withQualifier(entry.getKey(), entry.getValue());
             }
             try {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStep.java
@@ -36,7 +36,6 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -47,7 +46,6 @@ import hudson.FilePath;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.BufferedReader;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
@@ -100,18 +98,18 @@ public class PublishEiffelArtifactsStep extends Step {
 
         @Override
         protected Void run() throws Exception {
-            Run run = getContext().get(Run.class);
-            EiffelActivityAction action = run.getAction(EiffelActivityAction.class);
-            EiffelArtifactPublisher artifactPublisher = new EiffelArtifactPublisher(
+            var run = getContext().get(Run.class);
+            var action = run.getAction(EiffelActivityAction.class);
+            var artifactPublisher = new EiffelArtifactPublisher(
                     action.getTriggerEvent(), Util.getRunUri(run), run.getArtifactManager().root());
 
             try {
-                for (EiffelArtifactToPublishAction savedArtifact : run.getActions(EiffelArtifactToPublishAction.class)) {
+                for (var savedArtifact : run.getActions(EiffelArtifactToPublishAction.class)) {
                     publishArtifact(artifactPublisher, savedArtifact.getEvent());
                 }
 
                 if (step.getArtifactEventFiles() != null) {
-                    for (FilePath file : getContext().get(FilePath.class).list(step.getArtifactEventFiles())) {
+                    for (var file : getContext().get(FilePath.class).list(step.getArtifactEventFiles())) {
                         publishArtifactsFromFile(artifactPublisher, file);
                     }
                 }
@@ -125,8 +123,8 @@ public class PublishEiffelArtifactsStep extends Step {
 
         private void publishArtifact(@NonNull final EiffelArtifactPublisher artifactPublisher,
                                      @NonNull final EiffelArtifactCreatedEvent creationEvent) throws Exception {
-            EiffelArtifactPublishedEvent event = artifactPublisher.prepareEvent(creationEvent);
-            JsonNode sentJSON = Util.mustPublishEvent(event, true);
+            var event = artifactPublisher.prepareEvent(creationEvent);
+            var sentJSON = Util.mustPublishEvent(event, true);
             if (sentJSON != null) {
                 getContext().get(TaskListener.class).getLogger().format(
                         "Successfully sent %s with id %s for artifact with id %s%n",
@@ -138,12 +136,12 @@ public class PublishEiffelArtifactsStep extends Step {
         private void publishArtifactsFromFile(@NonNull final EiffelArtifactPublisher artifactPublisher,
                                               @NonNull final FilePath file) throws Exception {
             getContext().get(TaskListener.class).getLogger().format("Reading events from %s%n", file.getRemote());
-            try (InputStream is = file.read()) {
-                try (InputStreamReader isr = new InputStreamReader(is, StandardCharsets.UTF_8)) {
-                    try (BufferedReader br = new BufferedReader(isr)) {
+            try (var is = file.read()) {
+                try (var isr = new InputStreamReader(is, StandardCharsets.UTF_8)) {
+                    try (var br = new BufferedReader(isr)) {
                         String line;
                         while ((line = br.readLine()) != null) {
-                            EiffelEvent event = new ObjectMapper().readValue(line, EiffelEvent.class);
+                            var event = new ObjectMapper().readValue(line, EiffelEvent.class);
                             if (!(event instanceof EiffelArtifactCreatedEvent)) {
                                 throw new AbortException(String.format(
                                         "%s: This event in %s was of the type %s but only " +

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStep.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStep.java
@@ -32,7 +32,6 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidationFailedException;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.SchemaUnavailableException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -159,18 +158,18 @@ public class SendEiffelEventStep extends Step {
         @Override
         protected Map run() throws Exception {
             try {
-                ObjectMapper mapper = new ObjectMapper();
-                EiffelEvent event = mapper.convertValue(step.getEvent(), EiffelEvent.class);
-                Run run = getContext().get(Run.class);
+                var mapper = new ObjectMapper();
+                var event = mapper.convertValue(step.getEvent(), EiffelEvent.class);
+                var run = getContext().get(Run.class);
                 if (step.getLinkToActivity()) {
-                    EiffelActivityAction action = run.getAction(EiffelActivityAction.class);
+                    var action = run.getAction(EiffelActivityAction.class);
                     // There should always be an EiffelActivityAction connected to the Run,
                     // but if not we can't do much than to crash the build.
                     event.getLinks().add(new EiffelEvent.Link(
                             step.getActivityLinkType(), action.getTriggerEvent().getMeta().getId()));
                 }
-                JsonNode sentJSON = Util.mustPublishEvent(event, false);
-                TaskListener taskListener = getContext().get(TaskListener.class);
+                var sentJSON = Util.mustPublishEvent(event, false);
+                var taskListener = getContext().get(TaskListener.class);
                 if (sentJSON != null && taskListener != null) {
                     taskListener.getLogger().format(
                             "Successfully sent %s with id %s%n",

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderConfigurator.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderConfigurator.java
@@ -55,7 +55,7 @@ public class SepiaRoutingKeyProviderConfigurator extends BaseConfigurator<SepiaR
 
     @Override
     protected SepiaRoutingKeyProvider instance(Mapping mapping, ConfigurationContext context) throws ConfiguratorException {
-        SepiaRoutingKeyProvider provider = new SepiaRoutingKeyProvider();
+        var provider = new SepiaRoutingKeyProvider();
         if (mapping == null) {
             return provider;
         }
@@ -71,7 +71,7 @@ public class SepiaRoutingKeyProviderConfigurator extends BaseConfigurator<SepiaR
     @CheckForNull
     @Override
     public CNode describe(SepiaRoutingKeyProvider instance, ConfigurationContext context) throws Exception {
-        Mapping mapping = new Mapping();
+        var mapping = new Mapping();
         mapping.put(KEY_DUMMY, "dummy value to make JCasC behave the way we want");
         mapping.put(KEY_TAG, StringUtils.defaultIfBlank(instance.getTag(), ""));
         return mapping;

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
@@ -62,10 +62,10 @@ public class BuildWithEiffelLinksActionTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     public WebResponse postBuildRequest(final Job job, final String jsonPayload) throws IOException {
-        JenkinsRule.WebClient wc = jenkins.createWebClient();
+        var wc = jenkins.createWebClient();
         wc.getOptions().setThrowExceptionOnFailingStatusCode(false);
-        URL url = wc.createCrumbedUrl(job.getUrl() + BuildWithEiffelLinksAction.URL_SUFFIX + "/build");
-        WebRequest req = new WebRequest(url, HttpMethod.POST);
+        var url = wc.createCrumbedUrl(job.getUrl() + BuildWithEiffelLinksAction.URL_SUFFIX + "/build");
+        var req = new WebRequest(url, HttpMethod.POST);
         if (jsonPayload != null) {
             req.setRequestParameters(Arrays.asList(new NameValuePair("json", jsonPayload)));
         }
@@ -74,62 +74,62 @@ public class BuildWithEiffelLinksActionTest {
 
     @Test
     public void testNonParameterizedFreestyleBuild_WithoutParams() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_CREATED));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(notNullValue()));
 
-        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        var cause = (EiffelCause) build.getCause(EiffelCause.class);
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
-        ParametersAction paramAction = build.getAction(ParametersAction.class);
+        var paramAction = build.getAction(ParametersAction.class);
         assertThat(paramAction, is(nullValue()));
     }
 
     @Test
     public void testNonParameterizedFreestyleBuild_WithoutParams_WithoutLinks() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
         // Clear the links that are added by the constructor. The empty list
         // will be omitted when the object is serialized to JSON.
         reqParams.links.clear();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(nullValue()));
     }
 
     @Test
     public void testParameterizedFreestyleBuild_WithParams() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
         reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_CREATED));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(notNullValue()));
 
-        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        var cause = (EiffelCause) build.getCause(EiffelCause.class);
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
@@ -138,23 +138,23 @@ public class BuildWithEiffelLinksActionTest {
 
     @Test
     public void testParameterizedWorkflowBuild_WithParams() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        var job = jenkins.createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
         reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_CREATED));
 
-        WorkflowRun build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(notNullValue()));
 
-        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        var cause = (EiffelCause) build.getCause(EiffelCause.class);
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
@@ -163,31 +163,31 @@ public class BuildWithEiffelLinksActionTest {
 
     @Test
     public void testParameterizedFreestyleBuild_WithBadJsonPayload() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
 
-        WebResponse resp = postBuildRequest(job, "this is not valid JSON");
+        var resp = postBuildRequest(job, "this is not valid JSON");
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(nullValue()));
     }
 
     @Test
     public void testParameterizedFreestyleBuild_WithBadParameterJson() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
         reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
 
-        WebResponse resp = postBuildRequest(job, String.format(
+        var resp = postBuildRequest(job, String.format(
                 "{\"%s\": [], \"%s\": [[\"this can't be deserialized\"]]}",
                 BuildWithEiffelLinksAction.FORM_PARAM_EIFFELLINKS,
                 BuildWithEiffelLinksAction.FORM_PARAM_PARAMETERS));
@@ -195,47 +195,47 @@ public class BuildWithEiffelLinksActionTest {
 
         assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(nullValue()));
     }
 
     @Test
     public void testParameterizedFreestyleBuild_WithBadEiffelLinksJson() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
         reqParams.buildParams.add(new NameValuePair(stringParam.getName(), "overridden value"));
 
-        WebResponse resp = postBuildRequest(job, String.format(
+        var resp = postBuildRequest(job, String.format(
                 "{\"%s\": [[\"this can't be deserialized\"]]}",
                 BuildWithEiffelLinksAction.FORM_PARAM_EIFFELLINKS));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_BAD_REQUEST));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(nullValue()));
     }
 
     @Test
     public void testParameterizedFreestyleBuild_WithoutParams() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition stringParam = new StringParameterDefinition("STRING_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var stringParam = new StringParameterDefinition("STRING_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(stringParam));
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_CREATED));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(notNullValue()));
 
-        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        var cause = (EiffelCause) build.getCause(EiffelCause.class);
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 
@@ -244,24 +244,24 @@ public class BuildWithEiffelLinksActionTest {
 
     @Test
     public void testParameterizedFreestyleBuild_WithParamSubset() throws Exception {
-        BuildRequestParams reqParams = new BuildRequestParams();
+        var reqParams = new BuildRequestParams();
 
         // Define two parameters, GIVEN_PARAM and EXTRA_PARAM, but include only the former in the build request.
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
-        StringParameterDefinition givenParam = new StringParameterDefinition("GIVEN_PARAM", "value");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
+        var givenParam = new StringParameterDefinition("GIVEN_PARAM", "value");
         reqParams.buildParams.add(new NameValuePair(givenParam.getName(), "overridden value"));
-        StringParameterDefinition extraParam = new StringParameterDefinition("EXTRA_PARAM", "value");
+        var extraParam = new StringParameterDefinition("EXTRA_PARAM", "value");
         job.addProperty(new ParametersDefinitionProperty(givenParam, extraParam));
 
-        WebResponse resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
+        var resp = postBuildRequest(job, new ObjectMapper().writeValueAsString(reqParams));
         jenkins.waitUntilNoActivity();
 
         assertThat(resp.getStatusCode(), is(SC_CREATED));
 
-        AbstractBuild build = job.getBuildByNumber(1);
+        var build = job.getBuildByNumber(1);
         assertThat(build, is(notNullValue()));
 
-        EiffelCause cause = (EiffelCause) build.getCause(EiffelCause.class);
+        var cause = (EiffelCause) build.getCause(EiffelCause.class);
         assertThat(cause, is(notNullValue()));
         assertThat(cause.getLinks(), is(reqParams.links));
 

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConfigurationAsCodeTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConfigurationAsCodeTest.java
@@ -56,7 +56,7 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("jcasc-input-with-legacy-routing-key.yml")
     public void testSupportsConfigurationAsCode_WithLegacyRoutingKey() throws Exception {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         assertThat(config.getAppId(), is("random-appid"));
         assertThat(config.getEnableBroadcaster(), is(true));
         assertThat(config.getExchangeName(), is("eiffel-exchange"));
@@ -73,7 +73,7 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("jcasc-input-without-routing-key-provider.yml")
     public void testSupportsConfigurationAsCode_WithoutRoutingKeyProvider() throws Exception {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         assertThat(config.getAppId(), is("random-appid"));
         assertThat(config.getEnableBroadcaster(), is(true));
         assertThat(config.getExchangeName(), is("eiffel-exchange"));
@@ -88,7 +88,7 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("jcasc-input-with-fixed-routing-key-provider.yml")
     public void testSupportsConfigurationAsCode_WithFixedRoutingKeyProvider() throws Exception {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         assertThat(config.getAppId(), is("random-appid"));
         assertThat(config.getEnableBroadcaster(), is(true));
         assertThat(config.getExchangeName(), is("eiffel-exchange"));
@@ -105,7 +105,7 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("jcasc-input-with-sepia-routing-key-provider.yml")
     public void testSupportsConfigurationAsCode_WithSepiaRoutingKeyProvider() throws Exception {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         assertThat(config.getAppId(), is("random-appid"));
         assertThat(config.getEnableBroadcaster(), is(true));
         assertThat(config.getExchangeName(), is("eiffel-exchange"));
@@ -122,11 +122,10 @@ public class ConfigurationAsCodeTest {
     @Test
     @ConfiguredWithCode("jcasc-input-with-sepia-routing-key-provider.yml")
     public void testSupportsConfigurationExport() throws Exception {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
-        ConfigurationContext context = new ConfigurationContext(ConfiguratorRegistry.get());
-        String pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
-        CNode pluginNode = getUnclassifiedRoot(context).get(pluginShortName);
-        String sanitizedYAML = toYamlString(pluginNode)
+        var context = new ConfigurationContext(ConfiguratorRegistry.get());
+        var pluginShortName = EiffelBroadcasterConfig.class.getAnnotation(Symbol.class).value()[0];
+        var pluginNode = getUnclassifiedRoot(context).get(pluginShortName);
+        var sanitizedYAML = toYamlString(pluginNode)
                 .replaceFirst("(?m)^userPassword: .*(?:\\r?\\n)?", "")
                 .replaceFirst("(?m)^    dummy: .*(?:\\r?\\n)?", "");
         assertThat(sanitizedYAML, is(toStringFromYamlFile(this, "jcasc-expected-output.yml")));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/ConnectionIntegrationTest.java
@@ -87,12 +87,12 @@ public class ConnectionIntegrationTest {
      */
     @Before
     public void createProxyConnection() {
-        EiffelBroadcasterConfig config = EiffelBroadcasterConfig.getInstance();
+        var config = EiffelBroadcasterConfig.getInstance();
         assertThat(config, is(notNullValue()));
         TestUtil.setDefaultConfig(config);
         config.setServerUri(formatProxyServerUri());
 
-        MQConnection conn = MQConnection.getInstance();
+        var conn = MQConnection.getInstance();
         conn.initialize(config.getUserName(), config.getUserPassword(), config.getServerUri(), config.getVirtualHost());
     }
 
@@ -109,8 +109,8 @@ public class ConnectionIntegrationTest {
      */
     private String formatProxyServerUri() {
         ToxiproxyContainer.ContainerProxy proxy = getProxy();
-        final String ipAddressViaToxiproxy = proxy.getContainerIpAddress();
-        final int portViaToxiproxy = proxy.getProxyPort();
+        final var ipAddressViaToxiproxy = proxy.getContainerIpAddress();
+        final var portViaToxiproxy = proxy.getProxyPort();
         return "amqp://" + ipAddressViaToxiproxy + ":" + portViaToxiproxy;
     }
 
@@ -133,11 +133,11 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSentMessagesHaveCorrectFormat() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 10;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 10;
+        var expectedMessages = TestUtil.createEvents(messageCount);
         expectedMessages.forEach(this::publishSilently);
-        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+        var actualMessages = TestUtil.waitForMessages(
                 conn,
                 messageCount,
                 DEFAULT_MESSAGE_WAIT,
@@ -151,22 +151,22 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testConcurrentMessagePublishingWorks() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int batchSize = 1000;
-        int threadCount = 50;
+        var conn = MQConnection.getInstance();
+        var batchSize = 1000;
+        var threadCount = 50;
         // Just save the hashes of the events instead of the actual event objects to
         // save execution time. If there's a mismatch it's very unlikely we'll be able
         // to make sense of the diff between the giant collections anyway.
-        ArrayList<Integer> expectedMessageHashes = new ArrayList<>();
+        var expectedMessageHashes = new ArrayList<Integer>();
         // Prepare all publisher threads first, then start all of them at the same time (almost).
-        List<Thread> threads = new ArrayList<>();
-        for (int i = 0; i < threadCount; i++) {
-            ArrayList<EiffelEvent> batch = TestUtil.createEvents(batchSize);
+        var threads = new ArrayList<Thread>();
+        for (var i = 0; i < threadCount; i++) {
+            var batch = TestUtil.createEvents(batchSize);
             threads.add(new Thread(() -> batch.forEach(this::publishSilently)));
             expectedMessageHashes.addAll(batch.stream().map(EiffelEvent::hashCode).collect(Collectors.toList()));
         }
         threads.forEach(Thread::start);
-        List<Integer> actualMessageHashes = TestUtil.waitForMessages(
+        var actualMessageHashes = TestUtil.waitForMessages(
                 conn,
                 expectedMessageHashes.size(),
                 DEFAULT_MESSAGE_WAIT,
@@ -180,9 +180,9 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSentMessagesReceiveACKs() throws IOException, InterruptedException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 25;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 25;
+        var expectedMessages = TestUtil.createEvents(messageCount);
         expectedMessages.forEach(this::publishSilently);
         TestUtil.waitForMessages(
                 conn,
@@ -199,9 +199,9 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSendMessagesHandlesClosedConnection() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 1000;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 1000;
+        var expectedMessages = TestUtil.createEvents(messageCount);
 
         getProxy().setConnectionCut(true);
         executor.submit(() -> {
@@ -209,7 +209,7 @@ public class ConnectionIntegrationTest {
         });
         Thread.sleep(1000);
         getProxy().setConnectionCut(false);
-        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+        var actualMessages = TestUtil.waitForMessages(
                 conn,
                 messageCount,
                 DEFAULT_MESSAGE_WAIT,
@@ -223,9 +223,9 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSendMessagesHandlesUpstreamTimeout() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 1000;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 1000;
+        var expectedMessages = TestUtil.createEvents(messageCount);
         getProxy().toxics().timeout("timeout", ToxicDirection.UPSTREAM, 8000);
         executor.submit(() -> {
             expectedMessages.forEach(this::publishSilently);
@@ -246,9 +246,9 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSendMessagesHandlesConnectionFlicker() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 1000;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 1000;
+        var expectedMessages = TestUtil.createEvents(messageCount);
         executor.submit(() -> {
             expectedMessages.subList(0,500).forEach(this::publishSilently);
             try {
@@ -262,7 +262,7 @@ public class ConnectionIntegrationTest {
         getProxy().setConnectionCut(true);
         Thread.sleep(5000);
         getProxy().setConnectionCut(false);
-        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+        var actualMessages = TestUtil.waitForMessages(
                 conn,
                 messageCount,
                 DEFAULT_MESSAGE_WAIT,
@@ -276,14 +276,14 @@ public class ConnectionIntegrationTest {
      */
     @Test
     public void testSendMessagesHandlesLatency() throws InterruptedException, IOException {
-        MQConnection conn = MQConnection.getInstance();
-        int messageCount = 2;
-        ArrayList<EiffelEvent> expectedMessages = TestUtil.createEvents(messageCount);
+        var conn = MQConnection.getInstance();
+        var messageCount = 2;
+        var expectedMessages = TestUtil.createEvents(messageCount);
         getProxy().toxics().latency("latency", ToxicDirection.UPSTREAM, 2000).setJitter(2000);
         executor.submit(() -> {
             expectedMessages.forEach(this::publishSilently);
         });
-        ArrayList<EiffelEvent> actualMessages = TestUtil.waitForMessages(
+        var actualMessages = TestUtil.waitForMessages(
                 conn,
                 messageCount,
                 30,

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
@@ -49,26 +49,24 @@ public class EiffelArtifactPublisherTest {
 
     @Test(expected = EmptyArtifactException.class)
     public void testPrepareEvent_WithNoFilesInArtC() throws Exception {
-        URI jobURI = new URI("http://jenkins/job/MyJob/");
-        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
-        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
-        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
-                VirtualFile.forFile(tempDir.getRoot()));
+        var jobURI = new URI("http://jenkins/job/MyJob/");
+        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         publisher.prepareEvent(artC);
     }
 
     @Test
     public void testPrepareEvent_HasExpectedLinks() throws Exception {
-        ArtifactFiles files = new ArtifactFiles("filename.zip");
-        URI jobURI = new URI("http://jenkins/job/MyJob/");
-        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var files = new ArtifactFiles("filename.zip");
+        var jobURI = new URI("http://jenkins/job/MyJob/");
+        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
         files.addFilesToEvent(artC);
-        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
-        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
-                VirtualFile.forFile(tempDir.getRoot()));
+        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
-        EiffelArtifactPublishedEvent artP = publisher.prepareEvent(artC);
+        var artP = publisher.prepareEvent(artC);
 
         assertThat(artP, linksTo(actT, EiffelEvent.Link.Type.CONTEXT));
         assertThat(artP, linksTo(artC, EiffelEvent.Link.Type.ARTIFACT));
@@ -76,31 +74,29 @@ public class EiffelArtifactPublisherTest {
 
     @Test
     public void testPrepareEvent_WithFilesMatchingArtC() throws Exception {
-        ArtifactFiles files = new ArtifactFiles("filename.zip", "subdir/filename2.zip");
-        URI jobURI = new URI("http://jenkins/job/MyJob/");
-        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var files = new ArtifactFiles("filename.zip", "subdir/filename2.zip");
+        var jobURI = new URI("http://jenkins/job/MyJob/");
+        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
         files.addFilesToEvent(artC);
-        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
-        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
-                VirtualFile.forFile(tempDir.getRoot()));
+        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
-        EiffelArtifactPublishedEvent artP = publisher.prepareEvent(artC);
+        var artP = publisher.prepareEvent(artC);
 
         assertThat(artP.getData().getLocations(), containsInAnyOrder(files.getLocations(jobURI).toArray()));
     }
 
     @Test(expected = MissingArtifactException.class)
     public void testPrepareEvent_WithMissingFile() throws Exception {
-        ArtifactFiles files = new ArtifactFiles("filename.zip");
-        URI jobURI = new URI("http://jenkins/job/MyJob/");
-        EiffelArtifactCreatedEvent artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var files = new ArtifactFiles("filename.zip");
+        var jobURI = new URI("http://jenkins/job/MyJob/");
+        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
         // Add an extra artifact file directly to the event. This won't have a physical counterpart in tempDir.
         artC.getData().getFileInformation().add(
                 new EiffelArtifactCreatedEvent.Data.FileInformation("otherfile.txt"));
         files.addFilesToEvent(artC);
-        EiffelActivityTriggeredEvent actT = new EiffelActivityTriggeredEvent("dummy activity name");
-        EiffelArtifactPublisher publisher = new EiffelArtifactPublisher(actT, jobURI,
-                VirtualFile.forFile(tempDir.getRoot()));
+        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         publisher.prepareEvent(artC);
     }
@@ -115,22 +111,22 @@ public class EiffelArtifactPublisherTest {
         public ArtifactFiles(@NonNull final String... filenames) throws IOException {
             for (String filename : filenames) {
                 this.filenames.add(filename);
-                File file = new File(tempDir.getRoot(), filename);
+                var file = new File(tempDir.getRoot(), filename);
                 file.getParentFile().mkdirs();
                 file.createNewFile();
             }
         }
 
         public void addFilesToEvent(@NonNull final EiffelArtifactCreatedEvent event) {
-            for (String filename : filenames) {
+            for (var filename : filenames) {
                 event.getData().getFileInformation().add(new EiffelArtifactCreatedEvent.Data.FileInformation(filename));
             }
         }
 
         public List<EiffelArtifactPublishedEvent.Data.Location> getLocations(@NonNull final URI baseURI) {
-            List<EiffelArtifactPublishedEvent.Data.Location> result = new ArrayList<>();
-            for (String filename : filenames) {
-                EiffelArtifactPublishedEvent.Data.Location location = new EiffelArtifactPublishedEvent.Data.Location(
+            var result = new ArrayList<EiffelArtifactPublishedEvent.Data.Location>();
+            for (var filename : filenames) {
+                var location = new EiffelArtifactPublishedEvent.Data.Location(
                         EiffelArtifactPublishedEvent.Data.Location.Type.PLAIN, baseURI.resolve("artifact/" + filename));
                 location.setName(filename);
                 result.add(location);

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelEnvironmentContributorTest.java
@@ -50,13 +50,13 @@ public class EiffelEnvironmentContributorTest {
 
     @Test
     public void testEnvironmentVariablesAreAvailable_FreeStyle() throws Exception {
-        FreeStyleProject job = jenkins.createFreeStyleProject("test");
-        CaptureEnvironmentBuilder capture = new CaptureEnvironmentBuilder();
+        var job = jenkins.createFreeStyleProject("test");
+        var capture = new CaptureEnvironmentBuilder();
         job.getBuildersList().add(capture);
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        FreeStyleBuild run = job.getBuildByNumber(1);
-        EiffelActivityAction activityAction = run.getAction(EiffelActivityAction.class);
+        var run = job.getBuildByNumber(1);
+        var activityAction = run.getAction(EiffelActivityAction.class);
         assertThat(activityAction, is(notNullValue()));
 
         assertThat(capture.getEnvVars().get(EiffelEnvironmentContributor.ACTIVITY_STARTED),
@@ -67,8 +67,8 @@ public class EiffelEnvironmentContributorTest {
 
     @Test
     public void testEnvironmentVariablesAreAvailable_Pipeline() throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
-        String pipelineCode = String.format(
+        var job = jenkins.createProject(WorkflowJob.class, "test");
+        var pipelineCode = String.format(
                 "node {" +
                         "  if (isUnix()) {" +
                         "    sh('echo STARTED=$%s ; echo TRIGGER=$%s')" +
@@ -83,8 +83,8 @@ public class EiffelEnvironmentContributorTest {
         job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        WorkflowRun run = job.getBuildByNumber(1);
-        EiffelActivityAction activityAction = run.getAction(EiffelActivityAction.class);
+        var run = job.getBuildByNumber(1);
+        var activityAction = run.getAction(EiffelActivityAction.class);
         assertThat(activityAction, is(notNullValue()));
 
         jenkins.assertLogContains(String.format("STARTED=%s", activityAction.getStartedEventJSON()), run);

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -73,32 +73,32 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForSuccessfulFreestyleBuild() throws Exception {
-        FreeStyleProject job = jenkins.createFolder("testfolder")
+        var job = jenkins.createFolder("testfolder")
                 .createProject(FreeStyleProject.class, "test");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0, new Cause.UserIdCause()).get());
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
-        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
         assertThat(actT.getData().getName(), is("testfolder/test"));
         assertThat(actT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER, "SYSTEM"));
         assertThat(actT.getData().getCategories(), is(empty()));
 
-        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        var actS = events.findNext(EiffelActivityStartedEvent.class);
         assertThat(actS.getData().getExecutionUri().getPath(), containsString("testfolder/job/test/1"));
         assertThat(actS.getData().getLiveLogs(), not(emptyIterable()));
-        EiffelActivityStartedEvent.Data.LiveLogs liveLog = actS.getData().getLiveLogs().get(0);
+        var liveLog = actS.getData().getLiveLogs().get(0);
         assertThat(liveLog.getName(), is(RunListenerImpl.CONSOLE_LOG_NAME));
         assertThat(liveLog.getURI().getPath(), containsString("testfolder/job/test/1/consoleText"));
         assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
 
-        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        var actF = events.findNext(EiffelActivityFinishedEvent.class);
         assertThat(actF.getData().getOutcome().getConclusion(),
                 is(EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
         assertThat(actF.getData().getPersistentLogs(), not(emptyIterable()));
-        EiffelActivityFinishedEvent.Data.PersistentLogs persistentLog = actF.getData().getPersistentLogs().get(0);
+        var persistentLog = actF.getData().getPersistentLogs().get(0);
         assertThat(persistentLog.getName(), is(RunListenerImpl.CONSOLE_LOG_NAME));
         assertThat(persistentLog.getURI().getPath(), containsString("testfolder/job/test/1/consoleText"));
         assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
@@ -108,25 +108,25 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForSuccessfulFreestyleBuildSequence() throws Exception {
-        FreeStyleProject downstreamJob = jenkins.createProject(FreeStyleProject.class, "downstream");
+        var downstreamJob = jenkins.createProject(FreeStyleProject.class, "downstream");
 
-        FreeStyleProject upstreamJob = jenkins.createProject(FreeStyleProject.class, "upstream");
+        var upstreamJob = jenkins.createProject(FreeStyleProject.class, "upstream");
         upstreamJob.getPublishersList().add(new BuildTrigger(Collections.singletonList(downstreamJob), Result.SUCCESS));
 
         jenkins.jenkins.rebuildDependencyGraph();
         upstreamJob.scheduleBuild2(0);
         jenkins.waitUntilNoActivity();
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent upstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var upstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
         // Ignore the contents of the ActT event and the subsequent ActS and ActF events for
         // the upstream job. We're verifying them in other test cases and this test cases focuses
         // on trigger information for the downstream job's events.
         events.findNext(EiffelActivityStartedEvent.class);
         events.findNext(EiffelActivityFinishedEvent.class);
 
-        EiffelActivityTriggeredEvent downstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var downstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(downstreamActT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.EIFFEL_EVENT, "upstream"));
         assertThat(downstreamActT, linksTo(upstreamActT, EiffelEvent.Link.Type.CAUSE));
@@ -141,7 +141,7 @@ public class EmittedEventsTest {
     public void testEventsForCanceledFreestyleBuild() throws Exception {
         // Attempt to allocate a node with a label expression that won't ever be satisfied,
         // forcing it to end up in the queue so that we have time to cancel it.
-        FreeStyleProject job = jenkins.createFolder("testfolder")
+        var job = jenkins.createFolder("testfolder")
                 .createProject(FreeStyleProject.class, "test");
         job.setAssignedLabel(jenkins.jenkins.getLabel("no-such-node"));
 
@@ -152,12 +152,12 @@ public class EmittedEventsTest {
         job.scheduleBuild2(0);
         jenkins.jenkins.getQueue().clear();
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         // Ignore the contents of the ActT event; we're verifying its contents elsewhere.
 
-        EiffelActivityCanceledEvent actC = events.findNext(EiffelActivityCanceledEvent.class);
+        var actC = events.findNext(EiffelActivityCanceledEvent.class);
         assertThat(actC, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
 
         assertThat(events.isEmpty(), is(true));
@@ -165,34 +165,32 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForSuccessfulForMatrixBuild() throws Exception {
-        MatrixProject job = jenkins.createFolder("testfolder")
-                .createProject(MatrixProject.class, "test");
+        var job = jenkins.createFolder("testfolder").createProject(MatrixProject.class, "test");
         // Using more than one value on the axis would theoretically cover more cases,
         // but we'd have to spend more effort evaluating the resulting events.
-        String axisValue = "value1";
+        var axisValue = "value1";
         job.setAxes(new AxisList(new Axis("axislabel", axisValue)));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0, new Cause.UserIdCause()).get());
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
         // First check the ActT/ActS/ActF sequence of the top-level build.
-        EiffelActivityTriggeredEvent toplevelActT = events.findNext(EiffelActivityTriggeredEvent.class);
-        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        var toplevelActT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(toplevelActT.getData().getName(), is("testfolder/test"));
         assertThat(toplevelActT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER, "SYSTEM"));
         assertThat(toplevelActT.getData().getCategories(), is(empty()));
 
-        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class,
+        events.findNext(EiffelActivityStartedEvent.class,
                 linksTo(toplevelActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
         // Ignore the data members of the ActS event; we're verifying them elsewhere.
 
-        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class,
+        events.findNext(EiffelActivityFinishedEvent.class,
                 linksTo(toplevelActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
         // Ignore the data members of the ActF event; we're verifying them elsewhere.
 
         // Check that we get a child activity that has a CAUSE link to the main build's ActT event.
-        EiffelActivityTriggeredEvent childActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var childActT = events.findNext(EiffelActivityTriggeredEvent.class);
         // To avoid tight coupling to the exact build name let's just perform a sanity check
         // to make sure it contains the job name and the matrix axis value.
         assertThat(childActT.getData().getName(), containsString("test"));
@@ -205,7 +203,7 @@ public class EmittedEventsTest {
                 linksTo(childActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
         // Ignore the data members of the ActS event; we're verifying them elsewhere.
 
-        EiffelActivityFinishedEvent childActF = events.findNext(EiffelActivityFinishedEvent.class,
+        var childActF = events.findNext(EiffelActivityFinishedEvent.class,
                 linksTo(childActT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
         // Ignore the contents of the ActF event; we're verifying its contents elsewhere.
 
@@ -214,30 +212,29 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForSuccessfulPipelineBuild() throws Exception {
-        WorkflowJob job = jenkins.createFolder("testfolder")
+        var job = jenkins.createFolder("testfolder")
                 .createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
         jenkins.assertBuildStatus(Result.SUCCESS,
                 job.scheduleBuild2(0, new CauseAction(new Cause.UserIdCause())).get());
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
-        EiffelActivityTriggeredEvent.Data actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getName(), is("testfolder/test"));
         assertThat(actT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER, "SYSTEM"));
         assertThat(actT.getData().getCategories(), is(empty()));
 
-        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        var actS = events.findNext(EiffelActivityStartedEvent.class);
         // Ignore the data members of the ActS event; we're verifying them elsewhere.
         assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
 
-        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        var actF = events.findNext(EiffelActivityFinishedEvent.class);
         assertThat(actF.getData().getOutcome().getConclusion(),
                 is(EiffelActivityFinishedEvent.Data.Outcome.Conclusion.SUCCESSFUL));
         assertThat(actF.getData().getPersistentLogs(), not(emptyIterable()));
-        EiffelActivityFinishedEvent.Data.PersistentLogs persistentLog = actF.getData().getPersistentLogs().get(0);
+        var persistentLog = actF.getData().getPersistentLogs().get(0);
         assertThat(persistentLog.getName(), is(RunListenerImpl.CONSOLE_LOG_NAME));
         assertThat(persistentLog.getURI().getPath(), containsString("testfolder/job/test/1/consoleText"));
         assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
@@ -247,26 +244,26 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForSuccessfulPipelineBuildSequence() throws Exception {
-        WorkflowJob downstreamJob = jenkins.createProject(WorkflowJob.class, "downstream");
+        var downstreamJob = jenkins.createProject(WorkflowJob.class, "downstream");
         downstreamJob.setDefinition(new CpsFlowDefinition("echo 'hello'", true));
 
-        WorkflowJob upstreamJob = jenkins.createProject(WorkflowJob.class, "upstream");
-        String upstreamPipelineCode = String.format("build '%s'", downstreamJob.getFullName());
+        var upstreamJob = jenkins.createProject(WorkflowJob.class, "upstream");
+        var upstreamPipelineCode = String.format("build '%s'", downstreamJob.getFullName());
         upstreamJob.setDefinition(new CpsFlowDefinition(upstreamPipelineCode, true));
 
         upstreamJob.scheduleBuild2(0);
         jenkins.waitUntilNoActivity();
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent upstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var upstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
         // Ignore the contents of the ActT event and the subsequent ActS and ActF events for
         // the upstream job. We're verifying them in other test cases and this test case focuses
         // on trigger information for the downstream job's events.
         events.findNext(EiffelActivityStartedEvent.class);
         events.findNext(EiffelActivityFinishedEvent.class);
 
-        EiffelActivityTriggeredEvent downstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var downstreamActT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(downstreamActT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.EIFFEL_EVENT, "upstream"));
         assertThat(downstreamActT, linksTo(upstreamActT, EiffelEvent.Link.Type.CAUSE));
@@ -279,25 +276,25 @@ public class EmittedEventsTest {
 
     @Test
     public void testEventsForFailingPipelineBuild() throws Exception {
-        WorkflowJob job = jenkins.createFolder("testfolder")
+        var job = jenkins.createFolder("testfolder")
                 .createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition("node { error 'something went bad' }", true));
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         // Ignore the contents of the ActT event; we're verifying its contents elsewhere.
 
-        EiffelActivityStartedEvent actS = events.findNext(EiffelActivityStartedEvent.class);
+        var actS = events.findNext(EiffelActivityStartedEvent.class);
         // Ignore the data members of the ActS event; we're verifying them elsewhere.
         assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
 
-        EiffelActivityFinishedEvent actF = events.findNext(EiffelActivityFinishedEvent.class);
+        var actF = events.findNext(EiffelActivityFinishedEvent.class);
         assertThat(actF.getData().getOutcome().getConclusion(),
                 is(EiffelActivityFinishedEvent.Data.Outcome.Conclusion.FAILED));
         assertThat(actF.getData().getPersistentLogs(), not(emptyIterable()));
-        EiffelActivityFinishedEvent.Data.PersistentLogs persistentLog = actF.getData().getPersistentLogs().get(0);
+        var persistentLog = actF.getData().getPersistentLogs().get(0);
         assertThat(persistentLog.getName(), is(RunListenerImpl.CONSOLE_LOG_NAME));
         assertThat(persistentLog.getURI().getPath(), containsString("testfolder/job/test/1/consoleText"));
         assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
@@ -313,86 +310,86 @@ public class EmittedEventsTest {
 
     @Test
     public void testActivityActionsForSuccessfulFreestyleBuild() throws Exception {
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EiffelActivityAction action = job.getBuildByNumber(1).getAction(EiffelActivityAction.class);
-        EiffelActivityTriggeredEvent actT = action.getTriggerEvent();
+        var action = job.getBuildByNumber(1).getAction(EiffelActivityAction.class);
+        var actT = action.getTriggerEvent();
 
-        EiffelActivityStartedEvent actS = action.getStartedEvent();
+        var actS = action.getStartedEvent();
         assertThat(actS, is(notNullValue()));
         assertThat(actS, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
 
-        EiffelActivityFinishedEvent actF = action.getFinishedEvent();
+        var actF = action.getFinishedEvent();
         assertThat(actF, is(notNullValue()));
         assertThat(actF, linksTo(actT, EiffelEvent.Link.Type.ACTIVITY_EXECUTION));
     }
 
     @Test
     public void testActivityCategoriesForFreestyleBuildEmptyDefault() throws Exception {
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getCategories(), is(Collections.emptyList()));
     }
 
     @Test
     public void testActivityCategoriesForFreestyleBuildUsesGlobalConfig() throws Exception {
         EiffelBroadcasterConfig.getInstance().setActivityCategories("global category");
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getCategories(), is(Arrays.asList("global category")));
     }
 
     @Test
     public void testActivityCategoriesForFreestyleBuildUsesJobProperty() throws Exception {
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
         job.addProperty(new EiffelActivityJobProperty(Arrays.asList("job category")));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getCategories(), is(Arrays.asList("job category")));
     }
 
     @Test
     public void testActivityCategoriesForFreestyleBuildMergesGlobalAndJobProperties() throws Exception {
         EiffelBroadcasterConfig.getInstance().setActivityCategories("duplicate category\nglobal category");
-        FreeStyleProject job = jenkins.createProject(FreeStyleProject.class, "test");
+        var job = jenkins.createProject(FreeStyleProject.class, "test");
         job.addProperty(new EiffelActivityJobProperty(Arrays.asList("duplicate category", "job category")));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getCategories(),
                 is(Arrays.asList("duplicate category", "global category", "job category")));
     }
 
     @Test
     public void testActivityCategoriesForPipelineJobUsesJobProperty() throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        var job = jenkins.createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition("node { echo 'hello' }", true));
         job.addProperty(new EiffelActivityJobProperty(Arrays.asList("job category")));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
         assertThat(actT.getData().getCategories(), is(Arrays.asList("job category")));
     }
 
     @Test
     public void testActivityCategoriesForPipelineJobAllowsPropertySetting() throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        var job = jenkins.createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition(
                 "properties([eiffelActivity(categories: ['job category'])])", true));
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EventSet.java
@@ -50,7 +50,7 @@ public class EventSet {
      * the JSON string is malformed or if the mapping of the JSON object to a Java object fails
      */
     public EventSet(List<String> messages) throws JsonProcessingException {
-        ObjectMapper mapper = new ObjectMapper();
+        var mapper = new ObjectMapper();
         for (String message : messages) {
             events.add(mapper.readValue(message, EiffelEvent.class));
         }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
@@ -47,11 +47,11 @@ public class JenkinsSourceProviderTest {
 
     @Test
     public void testEventHasCorrectSource() throws Exception {
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        var event = new EiffelActivityTriggeredEvent("activity name");
         assertThat(event.getMeta().getSource(), is(notNullValue()));
         assertThat(event.getMeta().getSource().getName(), is("Eiffel Broadcaster Plugin"));
         assertThat(event.getMeta().getSource().getSerializer(), is(notNullValue()));
-        PackageURL purl = new PackageURL(event.getMeta().getSource().getSerializer());
+        var purl = new PackageURL(event.getMeta().getSource().getSerializer());
         assertThat(purl.getType(), is("maven"));
         assertThat(purl.getNamespace(), is("com.axis.jenkins.plugins.eiffel"));
         assertThat(purl.getName(), is("eiffel-broadcaster"));
@@ -61,7 +61,7 @@ public class JenkinsSourceProviderTest {
 
     @Test
     public void testSourceNameIsNotOverwritten() throws Exception {
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelActivityTriggeredEvent.json"), EiffelEvent.class);
         // We get the meta.source.name value from the JSON file
         assertThat(event.getMeta().getSource().getName(), is("Custom meta.source.name"));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventSigningTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventSigningTest.java
@@ -25,10 +25,7 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.security.KeyPair;
 import java.security.KeyPairGenerator;
-import java.security.PrivateKey;
-import java.security.PublicKey;
 import java.security.SecureRandom;
 import java.security.Signature;
 import java.security.spec.AlgorithmParameterSpec;
@@ -79,29 +76,28 @@ public class EiffelEventSigningTest {
 
     @Test
     public void testSigning() throws Exception {
-        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(signingAlg);
+        var keyGen = KeyPairGenerator.getInstance(signingAlg);
         if (algParamSpec != null) {
             keyGen.initialize(algParamSpec, new SecureRandom());
         }
 
-        KeyPair pair = keyGen.generateKeyPair();
-        PrivateKey priv = pair.getPrivate();
-        PublicKey pub = pair.getPublic();
+        var pair = keyGen.generateKeyPair();
+        var priv = pair.getPrivate();
+        var pub = pair.getPublic();
 
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        var event = new EiffelActivityTriggeredEvent("activity name");
         event.sign(priv, "CN=test", hashAlg);
 
         assertThat(event.getMeta().getSecurity(), is(notNullValue()));
         assertThat(event.getMeta().getSecurity().getAuthorIdentity(), is("CN=test"));
         assertThat(event.getMeta().getSecurity().getIntegrityProtection(), is(notNullValue()));
-        EiffelEvent.Meta.Security.IntegrityProtection.Alg actualEiffelAlg =
-                event.getMeta().getSecurity().getIntegrityProtection().getAlg();
+        var actualEiffelAlg = event.getMeta().getSecurity().getIntegrityProtection().getAlg();
         assertThat(actualEiffelAlg, is(eiffelAlg));
-        Signature sig = Signature.getInstance(actualEiffelAlg.getSignatureAlgorithm());
+        var sig = Signature.getInstance(actualEiffelAlg.getSignatureAlgorithm());
         sig.initVerify(pub);
 
-        ObjectMapper mapper = new ObjectMapper();
-        byte[] originalSignature = Base64.getDecoder().decode(
+        var mapper = new ObjectMapper();
+        var originalSignature = Base64.getDecoder().decode(
                 event.getMeta().getSecurity().getIntegrityProtection().getSignature());
         event.getMeta().getSecurity().getIntegrityProtection().setSignature("");
         sig.update(new JsonCanonicalizer(mapper.writeValueAsString(mapper.valueToTree(event))).getEncodedUTF8());

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
@@ -37,14 +37,14 @@ public class EiffelEventTest {
     public void testJsonDeserialization_ChoosesCorrectSubclass() throws JsonProcessingException {
         // We instantiate an arbitrary concrete EiffelEvent subclass and make sure that when we
         // deserialize the string back into an EiffelEvent we get an instance of the same class.
-        EiffelActivityTriggeredEvent originalEvent = new EiffelActivityTriggeredEvent("activity name");
-        EiffelEvent deserializedEvent = new ObjectMapper().readValue(originalEvent.toJSON(), EiffelEvent.class);
+        var originalEvent = new EiffelActivityTriggeredEvent("activity name");
+        var deserializedEvent = new ObjectMapper().readValue(originalEvent.toJSON(), EiffelEvent.class);
         assertThat(deserializedEvent, instanceOf(originalEvent.getClass()));
     }
 
     @Test
     public void testJsonDeserialization_WithGenericEventType() throws IOException {
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
         assertThat(event, instanceOf(GenericEiffelEvent.class));
     }
@@ -53,7 +53,7 @@ public class EiffelEventTest {
     public void testJsonDeserialization_WithLyonEvent() throws IOException {
         // Make sure we can deserialize an event from the Lyon edition,
         // and that an attribute that was added in that version is picked up.
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent_with_domainid_link.json"),
                 EiffelEvent.class);
         assertThat(event.getMeta().getVersion(), is("3.2.0"));
@@ -64,13 +64,12 @@ public class EiffelEventTest {
     public void testJsonDeserialization_WithAricaEvent() throws IOException {
         // Make sure we can deserialize an event from the Arica edition,
         // and that attributes that were added in that version are picked up.
-        EiffelArtifactCreatedEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelArtifactCreatedEvent_with_digest_and_schemauri.json"),
                 EiffelArtifactCreatedEvent.class);
         assertThat(event.getMeta().getVersion(), is("3.3.0"));
         assertThat(event.getMeta().getSchemaUri(), is("https://example.com/schema.json"));
-        EiffelArtifactCreatedEvent.Data.FileInformation.IntegrityProtection ip =
-                event.getData().getFileInformation().get(0).getIntegrityProtection();
+        var ip = event.getData().getFileInformation().get(0).getIntegrityProtection();
         assertThat(ip.getAlg(), is(EiffelArtifactCreatedEvent.Data.FileInformation.IntegrityProtection.Alg.SHA256));
         assertThat(ip.getDigest(), is("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
     }
@@ -84,14 +83,14 @@ public class EiffelEventTest {
     @Test
     public void testSourceProvider_WithDirectConstruction() throws IOException {
         EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        var event = new EiffelActivityTriggeredEvent("activity name");
         assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
     }
 
     @Test
     public void testSourceProvider_FromJsonToConcreteClass() throws IOException {
         EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelActivityTriggeredEvent.json"), EiffelEvent.class);
         assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
     }
@@ -99,7 +98,7 @@ public class EiffelEventTest {
     @Test
     public void testSourceProvider_FromJsonToGenericClass() throws IOException {
         EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
         // First make sure we actually get a GenericEiffelEvent object. If we introduce a concrete
         // class for EiffelCompositionDefinedEvent this testcase must be updated to not follow

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidatorTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidatorTest.java
@@ -30,23 +30,23 @@ import org.junit.Test;
 public class EventValidatorTest {
     @Test
     public void testValidateAcceptsValidEvent() throws Exception {
-        EventValidator validator = new EventValidator();
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        var validator = new EventValidator();
+        var event = new EiffelActivityTriggeredEvent("activity name");
         validator.validate(event.getMeta().getType(), event.getMeta().getVersion(),
                 new ObjectMapper().valueToTree(event));
     }
 
     @Test(expected = SchemaUnavailableException.class)
     public void testValidateRejectsUnknownEvent() throws Exception {
-        EventValidator validator = new EventValidator();
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
+        var validator = new EventValidator();
+        var event = new EiffelActivityTriggeredEvent("activity name");
         validator.validate("EiffelBogusEvent", "invalid.version",
                 new ObjectMapper().valueToTree(event));
     }
 
     @Test(expected = EventValidationFailedException.class)
     public void testValidateRejectsInvalidEvent() throws Exception {
-        EventValidator validator = new EventValidator();
+        var validator = new EventValidator();
         validator.validate("EiffelActivityTriggeredEvent", "4.0.0",
                 new ObjectMapper().readTree("{\"message\": \"this is an invalid event\"}"));
     }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/GenericEiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/GenericEiffelEventTest.java
@@ -35,7 +35,7 @@ import static org.hamcrest.Matchers.*;
 public class GenericEiffelEventTest {
     @Test
     public void testJsonDeserialization() throws IOException {
-        EiffelEvent event = new ObjectMapper().readValue(
+        var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
 
         // Basic metadata assertions. Make sure to include value apart from
@@ -54,7 +54,7 @@ public class GenericEiffelEventTest {
 
         // Make sure we get the expected concrete generic type and that its data is correct.
         assertThat(event, instanceOf(GenericEiffelEvent.class));
-        GenericEiffelEvent genericEvent = (GenericEiffelEvent) event;
+        var genericEvent = (GenericEiffelEvent) event;
         assertThat(genericEvent.getData().path("name").asText(), is("myCompositionName"));
         assertThat(genericEvent.getData().path("version").asText(), is("42.0.7"));
     }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/CreatePackageURLStepTest.java
@@ -36,7 +36,7 @@ public class CreatePackageURLStepTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     private WorkflowJob createJob(String purlCreationSnippet) throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
+        var job = jenkins.createProject(WorkflowJob.class, "test");
         job.setDefinition(new CpsFlowDefinition(
                 String.format("node { def purl = %s\necho \"PURL=${purl}\" }", purlCreationSnippet),
                 true));
@@ -45,7 +45,7 @@ public class CreatePackageURLStepTest {
 
     @Test
     public void testReturnsCorrectPurl() throws Exception {
-        WorkflowJob job = createJob(
+        var job = createJob(
                 "createPackageURL type: 'generic', namespace: 'name/space', " +
                         "name: 'pkgname', version: '1.0', subpath: 'some/path', qualifiers: [a: 'b']");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
@@ -58,7 +58,7 @@ public class CreatePackageURLStepTest {
     @Test
     public void testFailsOnMissingRequiredParam() throws Exception {
         // Leaving out the required "name" argument
-        WorkflowJob job = createJob("createPackageURL type: 'generic'");
+        var job = createJob("createPackageURL type: 'generic'");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains("Error creating package URL", job.getBuildByNumber(1));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
@@ -51,8 +51,8 @@ public class PublishEiffelArtifactsStepTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
-        String pipelineCode = new String(
+        var job = jenkins.createProject(WorkflowJob.class, "test");
+        var pipelineCode = new String(
                 Files.readAllBytes(Paths.get(getClass().getResource(pipelineCodeResourceFile).toURI())),
                 StandardCharsets.UTF_8.name());
         job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
@@ -79,12 +79,12 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testSuccessful_PublishesArtifacts() throws Exception {
-        WorkflowJob job = createJob("successful_publish_artifact_step.groovy");
+        var job = createJob("successful_publish_artifact_step.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        Run run = job.getBuildByNumber(1);
+        var run = job.getBuildByNumber(1);
         // We have pretty thorough tests of the ArtP contents for a given ArtC so here it's enough to
         // verify that we get the correct number of events and that the filenames in the events are what
         // we expect (so we're not getting two copies of the same event).
@@ -93,12 +93,12 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testSuccessful_PublishesArtifactsFromFile() throws Exception {
-        WorkflowJob job = createJob("successful_publish_artifact_step_from_file.groovy");
+        var job = createJob("successful_publish_artifact_step_from_file.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        Run run = job.getBuildByNumber(1);
+        var run = job.getBuildByNumber(1);
         // We have pretty thorough tests of the ArtP contents for a given ArtC so here it's enough to
         // verify that we get the correct number of events and that the filenames in the events are what
         // we expect (so we're not getting two copies of the same event).
@@ -108,7 +108,7 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testFailed_EventFromFileWithWrongType() throws Exception {
-        WorkflowJob job = createJob("failed_publish_artifact_step_from_file_bad_type.groovy");
+        var job = createJob("failed_publish_artifact_step_from_file_bad_type.groovy");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains(

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/SendEiffelEventStepTest.java
@@ -57,8 +57,8 @@ public class SendEiffelEventStepTest {
     public JenkinsRule jenkins = new JenkinsRule();
 
     private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
-        WorkflowJob job = jenkins.createProject(WorkflowJob.class, "test");
-        String pipelineCode = new String(
+        var job = jenkins.createProject(WorkflowJob.class, "test");
+        var pipelineCode = new String(
                 Files.readAllBytes(Paths.get(getClass().getResource(pipelineCodeResourceFile).toURI())),
                 StandardCharsets.UTF_8.name());
         job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
@@ -78,25 +78,25 @@ public class SendEiffelEventStepTest {
 
     @Test
     public void testSuccessful_WithDefaultLinkType() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_with_default_linktype.groovy");
+        var job = createJob("successful_send_event_step_with_default_linktype.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
-        GenericEiffelEvent cD = events.findNext(GenericEiffelEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var cD = events.findNext(GenericEiffelEvent.class);
         assertThat(cD.getMeta().getType(), is("EiffelCompositionDefinedEvent"));
         assertThat(cD, linksTo(actT, EiffelEvent.Link.Type.CONTEXT));
     }
 
     @Test
     public void testSuccessful_LogsEventDetails() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_with_default_linktype.groovy");
+        var job = createJob("successful_send_event_step_with_default_linktype.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        GenericEiffelEvent cD = events.findNext(GenericEiffelEvent.class);
+        var cD = events.findNext(GenericEiffelEvent.class);
         jenkins.assertLogContains(
                 String.format("Successfully sent %s with id %s", cD.getMeta().getType(), cD.getMeta().getId()),
                 job.getBuildByNumber(1));
@@ -104,52 +104,52 @@ public class SendEiffelEventStepTest {
 
     @Test
     public void testSuccessful_WithCustomLinkType() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_with_custom_linktype.groovy");
+        var job = createJob("successful_send_event_step_with_custom_linktype.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        EiffelActivityTriggeredEvent actT = events.findNext(EiffelActivityTriggeredEvent.class);
-        GenericEiffelEvent cD = events.findNext(GenericEiffelEvent.class);
+        var actT = events.findNext(EiffelActivityTriggeredEvent.class);
+        var cD = events.findNext(GenericEiffelEvent.class);
         assertThat(cD.getMeta().getType(), is("EiffelCompositionDefinedEvent"));
         assertThat(cD, linksTo(actT, EiffelEvent.Link.Type.CAUSE));
     }
 
     @Test
     public void testSuccessful_WithoutLink() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_without_link.groovy");
+        var job = createJob("successful_send_event_step_without_link.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        GenericEiffelEvent cD = events.findNext(GenericEiffelEvent.class);
+        var cD = events.findNext(GenericEiffelEvent.class);
         assertThat(cD.getLinks(), hasSize(0));
     }
 
     @Test
     public void testSuccessful_ReturnsSentMessage() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_with_payload_saved.groovy");
+        var job = createJob("successful_send_event_step_with_payload_saved.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
         // This job uses the writeJSON step to write the returned payload to event.json.
         // Deserialize that file and compare it against the event sent on the bus.
-        EiffelEvent eventWrittenToWorkspace = new ObjectMapper().readValue(
+        var eventWrittenToWorkspace = new ObjectMapper().readValue(
                 jenkins.jenkins.getWorkspaceFor(job).child("event.json").readToString(), EiffelEvent.class);
-        GenericEiffelEvent publishedEvent = events.findNext(GenericEiffelEvent.class);
+        var publishedEvent = events.findNext(GenericEiffelEvent.class);
         assertThat(publishedEvent, is(eventWrittenToWorkspace));
     }
 
     @Test
     public void testSuccessful_RecordsArtifacts() throws Exception {
-        WorkflowJob job = createJob("successful_send_event_step_with_artifacts.groovy");
+        var job = createJob("successful_send_event_step_with_artifacts.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
-        EventSet events = new EventSet(Mocks.messages);
+        var events = new EventSet(Mocks.messages);
 
-        Run run = job.getBuildByNumber(1);
-        List<EiffelArtifactToPublishAction> savedArtifacts = run.getActions(EiffelArtifactToPublishAction.class);
+        var run = job.getBuildByNumber(1);
+        var savedArtifacts = run.getActions(EiffelArtifactToPublishAction.class);
         assertThat(savedArtifacts, hasSize(2));
         assertThat(events.findNext(EiffelArtifactCreatedEvent.class), is(savedArtifacts.get(0).getEvent()));
         assertThat(events.findNext(EiffelArtifactCreatedEvent.class), is(savedArtifacts.get(1).getEvent()));
@@ -157,7 +157,7 @@ public class SendEiffelEventStepTest {
 
     @Test
     public void testFailed_EventValidationError() throws Exception {
-        WorkflowJob job = createJob("failed_send_event_step_event_validation_error.groovy");
+        var job = createJob("failed_send_event_step_event_validation_error.groovy");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains(
@@ -169,7 +169,7 @@ public class SendEiffelEventStepTest {
 
     @Test
     public void testFailed_EventWithoutType() throws Exception {
-        WorkflowJob job = createJob("failed_send_event_step_event_without_type.groovy");
+        var job = createJob("failed_send_event_step_event_without_type.groovy");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains(
@@ -181,7 +181,7 @@ public class SendEiffelEventStepTest {
 
     @Test
     public void testFailed_EventWithInvalidLinkType() throws Exception {
-        WorkflowJob job = createJob("failed_send_event_step_event_with_invalid_linktype.groovy");
+        var job = createJob("failed_send_event_step_event_with_invalid_linktype.groovy");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains(

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
@@ -34,24 +34,24 @@ import static org.hamcrest.Matchers.*;
 public class SepiaRoutingKeyProviderTest {
     @Test
     public void testGetRoutingKey_UsesUnderscoreInsteadOfNull() {
-        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
-        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var rp = new SepiaRoutingKeyProvider();
+        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._._"));
     }
 
     @Test
     public void testGetRoutingKey_UsesDomainIdIfSet() {
-        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
-        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var rp = new SepiaRoutingKeyProvider();
+        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
         event.getMeta().getSource().setDomainId("some-domainid");
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._.some-domainid"));
     }
 
     @Test
     public void testGetRoutingKey_UsesTagIfSet() {
-        SepiaRoutingKeyProvider rp = new SepiaRoutingKeyProvider();
+        var rp = new SepiaRoutingKeyProvider();
         rp.setTag("some-tag");
-        EiffelEvent event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent.some-tag._"));
     }
 }


### PR DESCRIPTION
Now that we've left Java 8 behind us we can change to using type inference for local variables. This reduces the verbosity of hundreds of statements and hopefully shifts the focus away from the types of the variables and towards what they're called and what's assigned to them.

This could be a controversial change and I'm not adamant about getting it merged, but I think it's an improvement.

### Testing done

All automated tests run. The patch should be functionally equivalent to the existing code and I wouldn't expect the byte code to differ.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```