### PR TITLE
README: Clarify that sendEiffelEvent returns the sent event

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ def event = [
 ]
 def sent = sendEiffelEvent event: event
 echo "This event was sent: ${sent}"
+echo "The event had the id ${sent.meta.id}"
 
 // Make the activity link a CAUSE link
 sendEiffelEvent event: event, activityLinkType: "CAUSE"
@@ -190,8 +191,10 @@ sendEiffelEvent event: event, linkToActivity: false
 
 This step returns immediately as soon as the event has been validated and put
 in the internal outbound queue. The actual delivery of the event to the broker
-might not have happened at the time of the return. The validation supports all
-events and event versions up to and including the
+might not have happened at the time of the return. The step's return value is
+the event that was enqueued, expressed as a map (see example above).
+
+The validation supports all events and event versions up to and including the
 [Orizaba edition](https://github.com/eiffel-community/eiffel/releases/tag/edition-orizaba).
 
 ## API


### PR DESCRIPTION
The documentation in README.md didn't state clearly that the sendEiffelEvent pipeline step returns the event that was sent (but the code example indicated that such was the case).

### Testing done

None; it's just a change in the Markdown prose.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
