### PR TITLE
Create new JenkinsRule subclass to reduce duplication

### DIFF
--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JobCreatingJenkinsRule.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JobCreatingJenkinsRule.java
@@ -1,0 +1,79 @@
+/**
+ The MIT License
+
+ Copyright 2024 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.model.TopLevelItemDescriptor;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import jenkins.model.Jenkins;
+import jenkins.model.ModifiableTopLevelItemGroup;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * A {@link JenkinsRule} specialization that contains a few convenience methods
+ * for creating jobs with a specific configuraiton.
+ */
+public class JobCreatingJenkinsRule extends JenkinsRule {
+    /**
+     * Create a pipeline job in a particular location and preload it with a pipeline
+     * definition from a given resource file.
+     *
+     * @param itemGroup the location of the new job
+     * @param sourceFile the filename of the resource file, relative to the test class,
+     *                   from which to load the pipeline definition
+     * @return the newly created job
+     * @throws IOException when the resource can't be loaded
+     * @throws URISyntaxException when the path to the resource can't be turned into a URL
+     */
+    public WorkflowJob createPipeline(@NonNull final ModifiableTopLevelItemGroup itemGroup,
+                                      @NonNull final String sourceFile)
+            throws IOException, URISyntaxException {
+        var job = (WorkflowJob) itemGroup.createProject(
+                (TopLevelItemDescriptor) Jenkins.get().getDescriptor(WorkflowJob.class), "test", true);
+        var pipelineCode = Files.readString(
+                Paths.get(getTestDescription().getTestClass().getResource(sourceFile).toURI()));
+        job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
+        return job;
+    }
+
+    /**
+     * Create a pipeline job and preload it with a pipeline definition from a given resource file.
+     *
+     * @param sourceFile the filename of the resource file, relative to the test class,
+     *                   from which to load the pipeline definition
+     * @return the newly created job
+     * @throws IOException when the resource can't be loaded
+     * @throws URISyntaxException when the path to the resource can't be turned into a URL
+     */
+    public WorkflowJob createPipeline(@NonNull final String sourceFile)
+            throws IOException, URISyntaxException {
+        return createPipeline(Jenkins.get(), sourceFile);
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/PublishEiffelArtifactsStepTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -26,38 +26,23 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelBroadcasterConfig;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EventSet;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.JobCreatingJenkinsRule;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Mocks;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
 import hudson.model.Result;
-import hudson.model.Run;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
-import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
-import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class PublishEiffelArtifactsStepTest {
     @Rule
-    public JenkinsRule jenkins = new JenkinsRule();
-
-    private WorkflowJob createJob(String pipelineCodeResourceFile) throws Exception {
-        var job = jenkins.createProject(WorkflowJob.class, "test");
-        var pipelineCode = new String(
-                Files.readAllBytes(Paths.get(getClass().getResource(pipelineCodeResourceFile).toURI())),
-                StandardCharsets.UTF_8.name());
-        job.setDefinition(new CpsFlowDefinition(pipelineCode, true));
-        return job;
-    }
+    public JobCreatingJenkinsRule jenkins = new JobCreatingJenkinsRule();
 
     private List<String> getLocationNames(EventSet events) {
         return events.all(EiffelArtifactPublishedEvent.class).stream()
@@ -79,7 +64,7 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testSuccessful_PublishesArtifacts() throws Exception {
-        var job = createJob("successful_publish_artifact_step.groovy");
+        var job = jenkins.createPipeline("successful_publish_artifact_step.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
         var events = new EventSet(Mocks.messages);
@@ -93,7 +78,7 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testSuccessful_PublishesArtifactsFromFile() throws Exception {
-        var job = createJob("successful_publish_artifact_step_from_file.groovy");
+        var job = jenkins.createPipeline("successful_publish_artifact_step_from_file.groovy");
         jenkins.assertBuildStatus(Result.SUCCESS, job.scheduleBuild2(0));
 
         var events = new EventSet(Mocks.messages);
@@ -108,7 +93,7 @@ public class PublishEiffelArtifactsStepTest {
 
     @Test
     public void testFailed_EventFromFileWithWrongType() throws Exception {
-        var job = createJob("failed_publish_artifact_step_from_file_bad_type.groovy");
+        var job = jenkins.createPipeline("failed_publish_artifact_step_from_file_bad_type.groovy");
         jenkins.assertBuildStatus(Result.FAILURE, job.scheduleBuild2(0));
 
         jenkins.assertLogContains(


### PR DESCRIPTION
We had duplicated code for creating a pipeline job and loading the pipeline code from a resource file. This wasn't too bad, but in the follow-up commit that'll conclude #99 we're planning to create such jobs in subfolders, which would make the problem worse. To reduce future pain we extract the code to methods in a new JenkinsRule subclass.

Its name, JobCreatingJenkinsRule, isn't very imaginative but maybe it's descriptive. If we want to widen the scope in the future it's easy enough to rename it.

### Testing done

Changes only affect tests so I've only verified that they still work.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```