### PR TITLE
HashAlgorithm: Remove #toString() so Stapler can serialize again

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/HashAlgorithm.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/HashAlgorithm.java
@@ -59,9 +59,4 @@ public enum HashAlgorithm {
     public String getDisplayName() {
         return displayName;
     }
-
-    @Override
-    public String toString() {
-        return displayName;
-    }
 }


### PR DESCRIPTION
When HashAlgorithm#fromString() was added in commit e17030e, we also added #toString(), perhaps in some kind of misguided desire for symmetry. Unfortunately, this prevented Stapler from serializing HashAlgorithm values since #toString() would return e.g. "SHA-256" which obviously doesn't match any of the enum values.

This is a bugfix for the work in #99.

### Testing done

Apart from running all tests I tested that saving the system configuration page worked (that's what failed prior to this commit). Also verified that system events as well as user events are sent.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
