### PR TITLE
Invalidate signature key cache when credentials change

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/signing/CredentialChangeListener.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/signing/CredentialChangeListener.java
@@ -1,0 +1,52 @@
+/**
+ The MIT License
+
+ Copyright 2024 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.signing;
+
+import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import hudson.Extension;
+import hudson.XmlFile;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Listens to changes in saveable objects and clears the cache of signing keys
+ * via {@link SigningKeyCache#clear()} when it's the XML file of
+ * the {@link SystemCredentialsProvider} that changed.
+ */
+@Extension
+public class CredentialChangeListener extends SaveableListener {
+    private static final Logger logger = LoggerFactory.getLogger(CredentialChangeListener.class);
+
+    /** Called when a change is made to a {@link Saveable} object. */
+    public void onChange(Saveable o, XmlFile file) {
+        if (!SystemCredentialsProvider.getConfigFile().getFile().equals(file.getFile())) {
+            return;
+        }
+        logger.info("Credentials changed, clearing cache");
+        SigningKeyCache.getInstance().clear();
+    }
+}

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/signing/SigningKeyCache.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/signing/SigningKeyCache.java
@@ -54,8 +54,13 @@ public class SigningKeyCache {
 
     private SigningKeyCache() { }
 
+    /** Clears the cache of all entries. */
+    public synchronized void clear() {
+        cache.clear();
+    }
+
     /**
-     * Looks up a credential by id and returns the identity (subject) of the certificate and the private key.
+     * Looks up a credential and returns the identity (subject) of the certificate and the private key.
      *
      * @param cred the credentials from which to extract the key and identity
      * @return an {@link Item} with the private key and identity
@@ -80,7 +85,7 @@ public class SigningKeyCache {
     }
 
     /** Returns the current number of (possibly expired) items in the cache. */
-    public int size() {
+    public synchronized int size() {
         return cache.size();
     }
 


### PR DESCRIPTION
Although we currently have a rather short TTL for the signature key cache (60 s), as a user I'd expect changes in credentials to take effect immediately. With a SaveableListener it's easy to trigger a flush of the cache when it's the SystemCredentialsProvider's XML file that changed.

This finally closes #99.

### Testing done

Automatic tests pass. Also tested manually that the cache clears after the credentials are modified.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```