### PR TITLE
publishEiffelArtifacts: Return published artifact events

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ The EiffelArtifactPublishedEvent will have two links; one ARTIFACT link to
 the EiffelArtifactCreatedEvent and one CONTEXT link to the parent build's
 EiffelActivityTriggeredEvent.
 
+This step returns immediately as soon as the event has been validated and put
+in the internal outbound queue. The actual delivery of the event to the broker
+might not have happened at the time of the return. The step's return value is
+a (possibly empty) list of enqueued events.
+
 | Argument            | Required | Description               |
 | --------------------|----------|---------------------------|
 | artifactEventFiles  |          | An Ant-style glob expression that selects files containing JSON representations (one per line) of EiffelArtifactCreatedEvent to publish. |

--- a/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step_with_payloads_saved.groovy
+++ b/src/test/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/successful_publish_artifact_step_with_payloads_saved.groovy
@@ -1,0 +1,50 @@
+import groovy.json.JsonOutput
+
+node {
+    def events = [
+            [
+                    'meta': [
+                            'type': 'EiffelArtifactCreatedEvent',
+                            'version': '3.0.0',
+                    ],
+                    'data': [
+                            'identity': 'pkg:generic/foo',
+                            'fileInformation': [
+                                    [
+                                            'name': 'a.txt',
+                                    ],
+                                    [
+                                            'name': 'b.txt',
+                                    ],
+                            ],
+                    ],
+            ],
+            [
+                    'meta': [
+                            'type': 'EiffelArtifactCreatedEvent',
+                            'version': '3.0.0',
+                    ],
+                    'data': [
+                            'identity': 'pkg:generic/foo',
+                            'fileInformation': [
+                                    [
+                                            'name': 'c.txt',
+                                    ],
+                                    [
+                                            'name': 'd.txt',
+                                    ],
+                            ],
+                    ],
+            ],
+    ]
+    events.collect { it.data.fileInformation }.flatten()*.name.each {
+        writeFile file: it, text: ''
+    }
+
+    sendEiffelEvent event: events[0], publishArtifact: true
+
+    archiveArtifacts artifacts: '*.txt'
+    writeFile file: 'artifacts.json', text: JsonOutput.toJson(events[1])
+    def publishedEvents = publishEiffelArtifacts artifactEventFiles: 'artifacts.json'
+    writeFile file: 'events.json', text: publishedEvents.collect { JsonOutput.toJson(it) }.join('\n')
+}


### PR DESCRIPTION
Similar to how the sendEiffelEvent step already works, the publishEiffelArtifacts step now returns a list of the published events.

### Testing done

Manual happy testing performed and all automated tests pass (including the test I added for this particular feature).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
