### PR TITLE
QueueListenerImplTest: Use local variable type inference

### DIFF
--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -27,7 +27,6 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
 import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import org.junit.Test;
 
@@ -40,13 +39,13 @@ import static org.hamcrest.Matchers.not;
 public class QueueListenerImplTest {
     @Test
     public void testAddTriggerFromEiffelCause_AddsAllLinks() {
-        List<EiffelEvent.Link> links = Arrays.asList(
+        var links = Arrays.asList(
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, UUID.randomUUID()),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, UUID.randomUUID()),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
-        EiffelCause cause = new EiffelCause(links);
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
-        QueueListenerImpl queueListener = new QueueListenerImpl();
+        var cause = new EiffelCause(links);
+        var event = new EiffelActivityTriggeredEvent("activity name");
+        var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
 
@@ -55,12 +54,12 @@ public class QueueListenerImplTest {
 
     @Test
     public void testAddTriggerFromEiffelCause_NoTriggerForNonCauseLink() {
-        List<EiffelEvent.Link> links = Arrays.asList(
+        var links = Arrays.asList(
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, UUID.randomUUID()),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
-        EiffelCause cause = new EiffelCause(links);
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
-        QueueListenerImpl queueListener = new QueueListenerImpl();
+        var cause = new EiffelCause(links);
+        var event = new EiffelActivityTriggeredEvent("activity name");
+        var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
 
@@ -69,19 +68,19 @@ public class QueueListenerImplTest {
 
     @Test
     public void testAddTriggerFromEiffelCause_TriggerForCauseLink() {
-        UUID cause1 = UUID.randomUUID();
-        UUID cause2 = UUID.randomUUID();
-        List<EiffelEvent.Link> links = Arrays.asList(
+        var cause1 = UUID.randomUUID();
+        var cause2 = UUID.randomUUID();
+        var links = Arrays.asList(
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause1),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause2));
-        EiffelCause cause = new EiffelCause(links);
-        EiffelActivityTriggeredEvent event = new EiffelActivityTriggeredEvent("activity name");
-        QueueListenerImpl queueListener = new QueueListenerImpl();
+        var cause = new EiffelCause(links);
+        var event = new EiffelActivityTriggeredEvent("activity name");
+        var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
 
         assertThat(event.getData().getTriggers(), not(emptyIterable()));
-        EiffelActivityTriggeredEvent.Data.Trigger trigger = event.getData().getTriggers().get(0);
+        var trigger = event.getData().getTriggers().get(0);
         assertThat(trigger.getType(), is(EiffelActivityTriggeredEvent.Data.Trigger.Type.EIFFEL_EVENT));
         assertThat(trigger.getDescription(), containsString(cause1.toString()));
         assertThat(trigger.getDescription(), containsString(cause2.toString()));


### PR DESCRIPTION
When we converted all code to use local variable type inference as much as possible in #105, it seems we simply forgot about QueueListenerImplTest. That was unintentional.

### Testing done

No functional changes, not even in the tests. But they pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
