### PR TITLE
Replace manual event instantiation with EiffelEventFactory

### DIFF
--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisher.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -27,6 +27,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Functions;
 import java.io.IOException;
@@ -97,7 +98,9 @@ public class EiffelArtifactPublisher {
         }
 
         // Sanity check okay, continue with the construction of the ArtP event.
-        var publishEvent = new EiffelArtifactPublishedEvent(creationEvent.getMeta().getId());
+        var publishEvent = EiffelEventFactory.getInstance().create(EiffelArtifactPublishedEvent.class);
+        publishEvent.getLinks().add(
+                new EiffelEvent.Link(EiffelEvent.Link.Type.ARTIFACT, creationEvent.getMeta().getId()));
         publishEvent.getLinks().add(
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, contextEvent.getMeta().getId()));
         for (var fileInfo : creationEvent.getData().getFileInformation()) {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelBroadcasterConfig.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2018-2022 Axis Communications AB.
+ Copyright 2018-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,7 @@
 
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EventValidator;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.HashAlgorithm;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys.FixedRoutingKeyProvider;
@@ -137,7 +137,7 @@ public final class EiffelBroadcasterConfig extends GlobalConfiguration {
 
     public EiffelBroadcasterConfig() {
         super.load();
-        EiffelEvent.setSourceProvider(new JenkinsSourceProvider());
+        EiffelEventFactory.getInstance().setSourceProvider(new JenkinsSourceProvider());
     }
 
     @Override

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityCanceledEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Objects;
-import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -42,20 +41,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityCanceledEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final Data data;
+    private Data data = new Data();
 
-    public EiffelActivityCanceledEvent() {
-        super("EiffelActivityCanceledEvent", "3.0.0");
-        this.data = new EiffelActivityCanceledEvent.Data();
+    public EiffelActivityCanceledEvent(final String version) {
+        super(EiffelActivityCanceledEvent.class.getSimpleName(), version);
     }
 
-    public EiffelActivityCanceledEvent(UUID activityID) {
-        this();
-        getLinks().add(new Link(Link.Type.ACTIVITY_EXECUTION, activityID));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelActivityCanceledEvent() {
+        this("");
     }
 
     public Data getData() {
         return data;
+    }
+
+    public void setData(Data data) {
+        this.data = data;
     }
 
     @Override

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityFinishedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -46,20 +45,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityFinishedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final Data data;
+    private Data data = new Data();
 
-    public EiffelActivityFinishedEvent(@JsonProperty("data") Data data) {
-        super("EiffelActivityFinishedEvent", "3.0.0");
-        this.data = data;
+    public EiffelActivityFinishedEvent(final String version) {
+        super(EiffelActivityFinishedEvent.class.getSimpleName(), version);
     }
 
-    public EiffelActivityFinishedEvent(Data.Outcome outcome, UUID activityID) {
-        this(new EiffelActivityFinishedEvent.Data(outcome));
-        getLinks().add(new EiffelEvent.Link(Link.Type.ACTIVITY_EXECUTION, activityID));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelActivityFinishedEvent() {
+        this("");
     }
 
     public Data getData() {
         return data;
+    }
+
+    public void setData(EiffelActivityFinishedEvent.Data data) {
+        this.data = data;
     }
 
     @Override
@@ -91,10 +93,6 @@ public class EiffelActivityFinishedEvent extends EiffelEvent {
         private Outcome outcome;
 
         private final List<PersistentLogs> persistentLogs = new ArrayList<>();
-
-        public Data(@JsonProperty("outcome") Outcome outcome) {
-            this.outcome = outcome;
-        }
 
         public Outcome getOutcome() {
             return outcome;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityStartedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -32,7 +32,6 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
@@ -46,20 +45,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityStartedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final Data data;
+    private Data data = new Data();
 
-    public EiffelActivityStartedEvent() {
-        super("EiffelActivityStartedEvent", "4.0.0");
-        this.data = new Data();
+    public EiffelActivityStartedEvent(final String version) {
+        super(EiffelActivityStartedEvent.class.getSimpleName(), version);
     }
 
-    public EiffelActivityStartedEvent(UUID activityID) {
-        this();
-        getLinks().add(new Link(Link.Type.ACTIVITY_EXECUTION, activityID));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelActivityStartedEvent() {
+        this("");
     }
 
     public Data getData() {
         return data;
+    }
+
+    public void setData(EiffelActivityStartedEvent.Data data) {
+        this.data = data;
     }
 
     @Override

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelActivityTriggeredEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -44,19 +44,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelActivityTriggeredEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final Data data;
+    private Data data = new Data();
 
-    public EiffelActivityTriggeredEvent(@JsonProperty("data") Data data) {
-        super("EiffelActivityTriggeredEvent", "4.0.0");
-        this.data = data;
+    public EiffelActivityTriggeredEvent(final String version) {
+        super(EiffelActivityTriggeredEvent.class.getSimpleName(), version);
     }
 
-    public EiffelActivityTriggeredEvent(String name) {
-        this(new EiffelActivityTriggeredEvent.Data(name));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelActivityTriggeredEvent() {
+        this("");
     }
 
     public Data getData() {
         return data;
+    }
+
+    public void setData(EiffelActivityTriggeredEvent.Data data) {
+        this.data = data;
     }
 
     @Override
@@ -95,10 +99,6 @@ public class EiffelActivityTriggeredEvent extends EiffelEvent {
 
         public List<String> getCategories() {
             return categories;
-        }
-
-        public Data(@JsonProperty("name") String name) {
-            this.name = name;
         }
 
         public String getName() {

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactCreatedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -45,19 +45,23 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelArtifactCreatedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final EiffelArtifactCreatedEvent.Data data;
+    private Data data = new Data();
 
-    public EiffelArtifactCreatedEvent(@JsonProperty("data") Data data) {
-        super("EiffelArtifactCreatedEvent", "3.0.0");
-        this.data = data;
+    public EiffelArtifactCreatedEvent(final String version) {
+        super(EiffelArtifactCreatedEvent.class.getSimpleName(), version);
     }
 
-    public EiffelArtifactCreatedEvent(String identity) {
-        this(new Data(identity));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelArtifactCreatedEvent() {
+        this("");
     }
 
     public EiffelArtifactCreatedEvent.Data getData() {
         return data;
+    }
+
+    public void setData(EiffelArtifactCreatedEvent.Data data) {
+        this.data = data;
     }
 
     @Override
@@ -100,10 +104,6 @@ public class EiffelArtifactCreatedEvent extends EiffelEvent {
         private List<String> dependsOn = new ArrayList<>();;
 
         private String name;
-
-        public Data(@JsonProperty("identity") String identity) {
-            this.identity = identity;
-        }
 
         public String getIdentity() {
             return identity;

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactPublishedEvent.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelArtifactPublishedEvent.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -32,13 +32,12 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 /**
  * A Java representation of an Eiffel event of the
  * <a href="https://github.com/eiffel-community/eiffel/blob/master/eiffel-vocabulary/EiffelArtifactPublishedEvent.md">
- * EiffelArtifactPublishedEvent</a> (ArtC) kind.
+ * EiffelArtifactPublishedEvent</a> (ArtP) kind.
  *
  * See the Eiffel event documentation for more on the meaning of the attributes.
  */
@@ -46,20 +45,22 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 @JsonDeserialize(using = JsonDeserializer.None.class)
 public class EiffelArtifactPublishedEvent extends EiffelEvent {
     @JsonInclude(JsonInclude.Include.ALWAYS)
-    private final EiffelArtifactPublishedEvent.Data data;
+    private Data data = new Data();
 
-    public EiffelArtifactPublishedEvent() {
-        super("EiffelArtifactPublishedEvent", "3.1.0");
-        this.data = new Data();
+    public EiffelArtifactPublishedEvent(final String version) {
+        super(EiffelArtifactPublishedEvent.class.getSimpleName(), version);
     }
 
-    public EiffelArtifactPublishedEvent(UUID artifactID) {
-        this();
-        getLinks().add(new Link(Link.Type.ARTIFACT, artifactID));
+    /** Package-private constructor needed for JSON deserialization. */
+    EiffelArtifactPublishedEvent() {
+        this("");
     }
-
     public EiffelArtifactPublishedEvent.Data getData() {
         return data;
+    }
+
+    public void setData(EiffelArtifactPublishedEvent.Data data) {
+        this.data = data;
     }
 
     @Override

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventFactory.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventFactory.java
@@ -1,0 +1,99 @@
+/**
+ The MIT License
+
+ Copyright 2024 Axis Communications AB.
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ */
+
+package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+/**
+ * Factory for all event classes that descend from {@link EiffelEvent}.
+ * Makes sure event instances are properly initialized, including
+ * the event version.
+ */
+public class EiffelEventFactory {
+    /**
+     * A mapping from Eiffel event types to the version that should be used when creating
+     * an event of that type. These versions correspond to the Paris edition of the protocol.
+     * This hardcoded mapping will eventually be replaced by a dynamic mapping that reads
+     * <a href="https://github.com/eiffel-community/eiffel/blob/master/event_manifest.yml">
+     *     event_manifest.yml
+     * </a> from the protocol repository.
+     */
+    private static final Map<Class, String> EVENT_TYPE_VERSIONS = Map.of(
+            EiffelActivityCanceledEvent.class, "3.0.0",
+            EiffelActivityFinishedEvent.class, "3.0.0",
+            EiffelActivityStartedEvent.class, "4.0.0",
+            EiffelActivityTriggeredEvent.class, "4.0.0",
+            EiffelArtifactCreatedEvent.class, "3.0.0",
+            EiffelArtifactPublishedEvent.class, "3.1.0"
+    );
+
+    private SourceProvider sourceProvider;
+
+    /**
+     * Creates an instance of the given class and initializes its standard fields
+     * (e.g. meta.id, meta.source, and meta.type). The caller is responsible for
+     * populating any remaining mandatory fields required by the schema.
+     *
+     * @param clazz the event class to instantiate
+     * @return an object of the given type
+     */
+    @NonNull
+    public <T extends EiffelEvent> T create(final Class<T> clazz) {
+        try {
+            var event = clazz.getConstructor(String.class).newInstance(EVENT_TYPE_VERSIONS.get(clazz));
+            populateSource(event);
+            return event;
+        } catch (IllegalAccessException | InstantiationException |
+                 InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException("Event factory unexpectedly failed (this is a bug)", e);
+        }
+    }
+
+    /** Populates meta.source for the given event. */
+    public void populateSource(@NonNull final EiffelEvent event) {
+        if (sourceProvider != null) {
+            sourceProvider.populateSource(event.getMeta().getSource());
+        }
+    }
+
+    /**
+     * Provide a {@link SourceProvider} instance that will be requested to provide a {@link EiffelEvent.Meta.Source}
+     * object for each event created after that point.
+     */
+    public void setSourceProvider(final SourceProvider provider) {
+        sourceProvider = provider;
+    }
+
+    /** Returns the singleton object of this class. */
+    public static EiffelEventFactory getInstance() {
+        return EiffelEventFactory.LazyEiffelEventFactorySingleton.INSTANCE;
+    }
+
+    private static class LazyEiffelEventFactorySingleton {
+        private static final EiffelEventFactory INSTANCE = new EiffelEventFactory();
+    }
+}

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/BuildWithEiffelLinksActionTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -26,17 +26,16 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import hudson.model.AbstractBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Job;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.StringParameterDefinition;
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,7 +45,6 @@ import org.htmlunit.WebResponse;
 import org.htmlunit.util.NameValuePair;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
-import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -284,10 +282,11 @@ public class BuildWithEiffelLinksActionTest {
         public final List<NameValuePair> buildParams = new ArrayList<>();
 
         BuildRequestParams() {
-            links.add(new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE,
-                    new EiffelActivityTriggeredEvent("activity name").getMeta().getId()));
-            links.add(new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT,
-                    new EiffelActivityTriggeredEvent("activity name").getMeta().getId()));
+            for (EiffelEvent.Link.Type type : List.of(EiffelEvent.Link.Type.CAUSE, EiffelEvent.Link.Type.CONTEXT)) {
+                var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+                event.getData().setName("activity name");
+                links.add(new EiffelEvent.Link(type, event.getMeta().getId()));
+            }
         }
     }
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EiffelArtifactPublisherTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -28,6 +28,7 @@ import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTr
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactPublishedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +51,10 @@ public class EiffelArtifactPublisherTest {
     @Test(expected = EmptyArtifactException.class)
     public void testPrepareEvent_WithNoFilesInArtC() throws Exception {
         var jobURI = new URI("http://jenkins/job/MyJob/");
-        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
-        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var artC = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
+        artC.getData().setIdentity("pkg:generic/foo");
+        var actT = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        actT.getData().setName("dummy activity name");
         var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         publisher.prepareEvent(artC);
@@ -61,9 +64,11 @@ public class EiffelArtifactPublisherTest {
     public void testPrepareEvent_HasExpectedLinks() throws Exception {
         var files = new ArtifactFiles("filename.zip");
         var jobURI = new URI("http://jenkins/job/MyJob/");
-        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var artC = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
+        artC.getData().setIdentity("pkg:generic/foo");
         files.addFilesToEvent(artC);
-        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var actT = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        actT.getData().setName("dummy activity name");
         var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         var artP = publisher.prepareEvent(artC);
@@ -76,9 +81,11 @@ public class EiffelArtifactPublisherTest {
     public void testPrepareEvent_WithFilesMatchingArtC() throws Exception {
         var files = new ArtifactFiles("filename.zip", "subdir/filename2.zip");
         var jobURI = new URI("http://jenkins/job/MyJob/");
-        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var artC = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
+        artC.getData().setIdentity("pkg:generic/foo");
         files.addFilesToEvent(artC);
-        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var actT = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        actT.getData().setName("dummy activity name");
         var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         var artP = publisher.prepareEvent(artC);
@@ -90,12 +97,14 @@ public class EiffelArtifactPublisherTest {
     public void testPrepareEvent_WithMissingFile() throws Exception {
         var files = new ArtifactFiles("filename.zip");
         var jobURI = new URI("http://jenkins/job/MyJob/");
-        var artC = new EiffelArtifactCreatedEvent("pkg:generic/foo");
+        var artC = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
+        artC.getData().setIdentity("pkg:generic/foo");
         // Add an extra artifact file directly to the event. This won't have a physical counterpart in tempDir.
         artC.getData().getFileInformation().add(
                 new EiffelArtifactCreatedEvent.Data.FileInformation("otherfile.txt"));
         files.addFilesToEvent(artC);
-        var actT = new EiffelActivityTriggeredEvent("dummy activity name");
+        var actT = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        actT.getData().setName("dummy activity name");
         var publisher = new EiffelArtifactPublisher(actT, jobURI, VirtualFile.forFile(tempDir.getRoot()));
 
         publisher.prepareEvent(artC);

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/EmittedEventsTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -86,7 +86,6 @@ public class EmittedEventsTest {
         var events = new EventSet(Mocks.messages);
 
         var actT = events.findNext(EiffelActivityTriggeredEvent.class);
-        var actTData = new EiffelActivityTriggeredEvent.Data("testfolder/test");
         assertThat(actT.getData().getName(), is("testfolder/test"));
         assertThat(actT,
                 hasTrigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER, "SYSTEM"));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/JenkinsSourceProviderTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.packageurl.PackageURL;
 import org.junit.BeforeClass;
@@ -48,7 +49,8 @@ public class JenkinsSourceProviderTest {
 
     @Test
     public void testEventHasCorrectSource() throws Exception {
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         assertThat(event.getMeta().getSource(), is(notNullValue()));
         assertThat(event.getMeta().getSource().getName(), is("Eiffel Broadcaster Plugin"));
         assertThat(event.getMeta().getSource().getSerializer(), is(notNullValue()));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/QueueListenerImplTest.java
@@ -26,6 +26,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import java.util.Arrays;
 import java.util.UUID;
 import org.junit.Test;
@@ -44,7 +45,8 @@ public class QueueListenerImplTest {
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, UUID.randomUUID()),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
         var cause = new EiffelCause(links);
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
@@ -58,7 +60,8 @@ public class QueueListenerImplTest {
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CONTEXT, UUID.randomUUID()),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.FLOW_CONTEXT, UUID.randomUUID()));
         var cause = new EiffelCause(links);
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));
@@ -74,7 +77,8 @@ public class QueueListenerImplTest {
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause1),
                 new EiffelEvent.Link(EiffelEvent.Link.Type.CAUSE, cause2));
         var cause = new EiffelCause(links);
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         var queueListener = new QueueListenerImpl();
         queueListener.addTriggerFromEiffelCause(cause, event,
                 new EiffelActivityTriggeredEvent.Data.Trigger(EiffelActivityTriggeredEvent.Data.Trigger.Type.OTHER));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/SourceProviderResetter.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/SourceProviderResetter.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2022 Axis Communications AB.
+ Copyright 2022-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +25,7 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import hudson.Extension;
 import hudson.init.TermMilestone;
 import hudson.init.Terminator;
@@ -39,6 +40,6 @@ import hudson.init.Terminator;
 public class SourceProviderResetter {
     @Terminator(before=TermMilestone.COMPLETED)
     public static void resetSourceProvider() {
-        EiffelEvent.setSourceProvider(null);
+        EiffelEventFactory.getInstance().setSourceProvider(null);
     }
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/TestUtil.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/TestUtil.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2020 Axis Communications AB.
+ Copyright 2020-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.rabbitmq.client.AMQP;
 import com.rabbitmq.client.Channel;
@@ -36,8 +37,6 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import org.testcontainers.containers.RabbitMQContainer;
 
 /**
@@ -148,9 +147,13 @@ public final class TestUtil {
      * @return list of events
      */
     public static ArrayList<EiffelEvent> createEvents(int count) {
-        return IntStream.range(1, count + 1)
-                .mapToObj(i -> new EiffelArtifactCreatedEvent(String.format("pkg:test@%d", i)))
-                .collect(Collectors.toCollection(ArrayList::new));
+        var result = new ArrayList<EiffelEvent>();
+        for (int i = 0; i < count; i++) {
+            var artC = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
+            artC.getData().setIdentity(String.format("pkg:test@%d", i));
+            result.add(artC);
+        }
+        return result;
     }
 
 }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventSigningTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventSigningTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2023 Axis Communications AB.
+ Copyright 2023-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -85,7 +85,8 @@ public class EiffelEventSigningTest {
         var priv = pair.getPrivate();
         var pub = pair.getPublic();
 
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         event.sign(priv, "CN=test", hashAlg);
 
         assertThat(event.getMeta().getSecurity(), is(notNullValue()));

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EiffelEventTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -38,7 +38,8 @@ public class EiffelEventTest {
     public void testJsonDeserialization_ChoosesCorrectSubclass() throws JsonProcessingException {
         // We instantiate an arbitrary concrete EiffelEvent subclass and make sure that when we
         // deserialize the string back into an EiffelEvent we get an instance of the same class.
-        var originalEvent = new EiffelActivityTriggeredEvent("activity name");
+        var originalEvent = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        originalEvent.getData().setName("activity name");
         var deserializedEvent = new ObjectMapper().readValue(originalEvent.toJSON(), EiffelEvent.class);
         assertThat(deserializedEvent, instanceOf(originalEvent.getClass()));
     }
@@ -83,14 +84,15 @@ public class EiffelEventTest {
 
     @Test
     public void testSourceProvider_WithDirectConstruction() throws IOException {
-        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        EiffelEventFactory.getInstance().setSourceProvider(new DummyDomainIdProvider());
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
     }
 
     @Test
     public void testSourceProvider_FromJsonToConcreteClass() throws IOException {
-        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
+        EiffelEventFactory.getInstance().setSourceProvider(new DummyDomainIdProvider());
         var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelActivityTriggeredEvent.json"), EiffelEvent.class);
         assertThat(event.getMeta().getSource().getDomainId(), is(DummyDomainIdProvider.DOMAIN_ID));
@@ -98,7 +100,7 @@ public class EiffelEventTest {
 
     @Test
     public void testSourceProvider_FromJsonToGenericClass() throws IOException {
-        EiffelEvent.setSourceProvider(new DummyDomainIdProvider());
+        EiffelEventFactory.getInstance().setSourceProvider(new DummyDomainIdProvider());
         var event = new ObjectMapper().readValue(
                 getClass().getResourceAsStream("EiffelCompositionDefinedEvent.json"), EiffelEvent.class);
         // First make sure we actually get a GenericEiffelEvent object. If we introduce a concrete

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidatorTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/eiffel/EventValidatorTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2021 Axis Communications AB.
+ Copyright 2021-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -31,7 +31,8 @@ public class EventValidatorTest {
     @Test
     public void testValidateAcceptsValidEvent() throws Exception {
         var validator = new EventValidator();
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         validator.validate(event.getMeta().getType(), event.getMeta().getVersion(),
                 new ObjectMapper().valueToTree(event));
     }
@@ -39,7 +40,8 @@ public class EventValidatorTest {
     @Test(expected = SchemaUnavailableException.class)
     public void testValidateRejectsUnknownEvent() throws Exception {
         var validator = new EventValidator();
-        var event = new EiffelActivityTriggeredEvent("activity name");
+        var event = EiffelEventFactory.getInstance().create(EiffelActivityTriggeredEvent.class);
+        event.getData().setName("activity name");
         validator.validate("EiffelBogusEvent", "invalid.version",
                 new ObjectMapper().valueToTree(event));
     }

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/routingkeys/SepiaRoutingKeyProviderTest.java
@@ -1,7 +1,7 @@
 /**
  The MIT License
 
- Copyright 2023 Axis Communications AB.
+ Copyright 2023-2024 Axis Communications AB.
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
  of this software and associated documentation files (the "Software"), to deal
@@ -25,7 +25,7 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.routingkeys;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelArtifactCreatedEvent;
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEvent;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelEventFactory;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,14 +35,14 @@ public class SepiaRoutingKeyProviderTest {
     @Test
     public void testGetRoutingKey_UsesUnderscoreInsteadOfNull() {
         var rp = new SepiaRoutingKeyProvider();
-        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var event = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._._"));
     }
 
     @Test
     public void testGetRoutingKey_UsesDomainIdIfSet() {
         var rp = new SepiaRoutingKeyProvider();
-        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var event = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
         event.getMeta().getSource().setDomainId("some-domainid");
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent._.some-domainid"));
     }
@@ -51,7 +51,7 @@ public class SepiaRoutingKeyProviderTest {
     public void testGetRoutingKey_UsesTagIfSet() {
         var rp = new SepiaRoutingKeyProvider();
         rp.setTag("some-tag");
-        var event = new EiffelArtifactCreatedEvent("pkg:generic/package");
+        var event = EiffelEventFactory.getInstance().create(EiffelArtifactCreatedEvent.class);
         assertThat(rp.getRoutingKey(event), is("eiffel._.EiffelArtifactCreatedEvent.some-tag._"));
     }
 }


### PR DESCRIPTION
This is a first step towards #62 (which, in turn, enables supporting newer protocol features like the ORIGINAL_TRIGGER link type). Previously each event class has hardcoded its version. We want to support central configuration of the Eiffel edition to use for outbound events, and to avoid having a dependency to that configuration from each event class we introduce a factory class. Right now the factory only has a hardcoded event table, but that'll change in a follow-up commit.

We also move the SourceProvider from EiffelEvent to EiffelEventFactory, making the event classes pure POJOs.

The drawback of the factory is that the classes are dumb in the sense that their constructors no longer take parameters for mandatory fields, i.e. it's less obvious what input you really need to provide to get a valid event in the end.

### Testing done

All automatic tests pass. Performed manual tests that together should exercise most code. Inspected the events produced during the manual tests and didn't find anything out of the ordinary.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
