### PR TITLE
Replace inheritance in BuildWithEiffelStep

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ in each job. Duplicate entries will be eliminated.
 
 ### buildWithEiffel
 
-The buildWithEiffel pipeline step is an extension of [BuildTriggerStep](https://github.com/jenkinsci/pipeline-build-step-plugin/blob/491.v1fec530da_858/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java)
+The buildWithEiffel pipeline step is a modified copy of [BuildTriggerStep](https://github.com/jenkinsci/pipeline-build-step-plugin/blob/491.v1fec530da_858/src/main/java/org/jenkinsci/plugins/workflow/support/steps/build/BuildTriggerStep.java)
 from [pipeline-build-step-plugin 491.v1fec530da_858](https://github.com/jenkinsci/pipeline-build-step-plugin/tree/491.v1fec530da_858) that can override event data in the EiffelActivityTriggeredEvent (ActT) that is sent when the triggered downstream build enters the
 build queue. Currently, `data.name` can be overridden.
 

--- a/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStep.java
+++ b/src/main/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStep.java
@@ -25,31 +25,73 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.build;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.EiffelActivityDataAction;
+import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Messages;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.QueueListenerImpl;
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.eiffel.EiffelActivityTriggeredEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import hudson.Extension;
+import hudson.model.AutoCompletionCandidates;
+import hudson.model.Describable;
+import hudson.model.Item;
+import hudson.model.ItemGroup;
+import hudson.model.ItemVisitor;
+import hudson.model.Job;
+import hudson.model.ParameterDefinition;
+import hudson.model.ParameterValue;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.PasswordParameterDefinition;
+import hudson.model.PasswordParameterValue;
+import hudson.model.Queue;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.util.FormValidation;
+import hudson.util.Secret;
+import jenkins.model.Jenkins;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.structs.describable.CustomDescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.UninstantiatedDescribable;
+import org.jenkinsci.plugins.workflow.graph.FlowNode;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
+import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.jenkinsci.plugins.workflow.steps.StepExecution;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStep;
 import org.jenkinsci.plugins.workflow.support.steps.build.BuildTriggerStepExecution;
+import org.jenkinsci.plugins.workflow.util.StaplerReferer;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.DoNotUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+
 /**
- * Defines a pipeline step that extends {@link BuildTriggerStep} to trigger a downstream build
+ * Defines a pipeline step that is a modified copy of {@link BuildTriggerStep} to trigger a downstream build
  * with a custom activity name set in the Eiffel activity event {@link EiffelActivityTriggeredEvent} ActT.
  *
- * The step execution is overriden to use a modified copy of {@link BuildTriggerStepExecution} that will
+ * The step execution is overridden to use a modified copy of {@link BuildTriggerStepExecution} that will
  * add a new build action {@link EiffelActivityDataAction} to the downstream build that stores
  * the ActT activity name. This action is then used in {@link QueueListenerImpl} to override the
  * activity name when a new ActT is fired as the downstream build enters a waiting state in the build queue.
  */
-public class BuildWithEiffelStep extends BuildTriggerStep {
+public class BuildWithEiffelStep extends Step {
 
     /**
      * The activity name of the Eiffel activity event {@link EiffelActivityTriggeredEvent} ActT
@@ -57,9 +99,17 @@ public class BuildWithEiffelStep extends BuildTriggerStep {
      * */
     private String activityName;
 
+    // BuildTriggerStep fields
+    private final String job;
+    private List<ParameterValue> parameters;
+    private boolean wait = true;
+    private boolean waitForStart = false;
+    private boolean propagate = true;
+    private Integer quietPeriod;
+
     @DataBoundConstructor
     public BuildWithEiffelStep(String job) {
-        super(job);
+        this.job = job;
     }
 
     public String getActivityName() {
@@ -71,12 +121,161 @@ public class BuildWithEiffelStep extends BuildTriggerStep {
         this.activityName = activityName;
     }
 
+    // BuildTriggerStep getters and setters
+    public String getJob() {
+        return job;
+    }
+
+    public List<ParameterValue> getParameters() {
+        return parameters;
+    }
+
+    @DataBoundSetter public void setParameters(List<ParameterValue> parameters) {
+        this.parameters = parameters;
+    }
+
+    public boolean getWait() {
+        return wait;
+    }
+
+    @DataBoundSetter public void setWait(boolean wait) {
+        this.wait = wait;
+    }
+
+    public boolean getWaitForStart() {
+        return waitForStart;
+    }
+
+    @DataBoundSetter public void setWaitForStart(boolean waitForStart) {
+        this.waitForStart = waitForStart;
+    }
+
+    public Integer getQuietPeriod() {
+        return quietPeriod;
+    }
+
+    @DataBoundSetter public void setQuietPeriod(Integer quietPeriod) {
+        this.quietPeriod = quietPeriod;
+    }
+
+    public boolean isPropagate() {
+        return propagate;
+    }
+
+    @DataBoundSetter public void setPropagate(boolean propagate) {
+        this.propagate = propagate;
+    }
+
     @Extension
-    public static class DescriptorImpl extends BuildTriggerStep.DescriptorImpl {
+    public static class DescriptorImpl extends StepDescriptor implements CustomDescribableModel {
+
+        // Note: This is necessary because the JSON format of the parameters produced by config.jelly when
+        // using the snippet generator does not match what would be necessary for databinding to work automatically.
+        // Only called via the snippet generator.
+        @Override public Step newInstance(@Nullable StaplerRequest req, @NonNull JSONObject formData) throws FormException {
+            BuildWithEiffelStep step = (BuildWithEiffelStep) super.newInstance(req, formData);
+            // Cf. ParametersDefinitionProperty._doBuild:
+            Object parameter = formData.get("parameter");
+            JSONArray params = parameter != null ? JSONArray.fromObject(parameter) : null;
+            if (params != null) {
+                Job<?,?> context = StaplerReferer.findItemFromRequest(Job.class);
+                Job<?,?> job = Jenkins.get().getItem(step.getJob(), context, Job.class);
+                if (job != null) {
+                    ParametersDefinitionProperty pdp = job.getProperty(ParametersDefinitionProperty.class);
+                    if (pdp != null) {
+                        List<ParameterValue> values = new ArrayList<>();
+                        for (Object o : params) {
+                            JSONObject jo = (JSONObject) o;
+                            String name = jo.getString("name");
+                            ParameterDefinition d = pdp.getParameterDefinition(name);
+                            if (d == null) {
+                                throw new IllegalArgumentException("No such parameter definition: " + name);
+                            }
+                            ParameterValue parameterValue;
+                            if (d instanceof PasswordParameterDefinition) {
+                                parameterValue = req.bindJSON(PasswordParameterValue.class, jo);
+                                parameterValue.setDescription(d.getDescription());
+                            } else {
+                                parameterValue = d.createValue(req, jo);
+                            }
+                            if (parameterValue != null) {
+                                values.add(parameterValue);
+                            } else {
+                                throw new IllegalArgumentException("Cannot retrieve the parameter value: " + name);
+                            }
+                        }
+                        step.setParameters(values);
+                    }
+                }
+            }
+            return step;
+        }
+
+        /**
+         * Compatibility hack for JENKINS-62305. Only affects runtime behavior of the step, not the snippet generator.
+         * Ideally, password parameters would not be used at all with this step, but there was no documentation or
+         * runtime warnings for this usage previously and so it is relatively common.
+         */
+        @NonNull
+        @Override
+        public Map<String, Object> customInstantiate(@NonNull Map<String, Object> map) {
+            if (DescribableModel.of(PasswordParameterValue.class).getParameter("value").getErasedType() != Secret.class) {
+                return map;
+            }
+            return copyMapReplacingEntry(map, "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newArguments = copyMapReplacingEntry(ud.getArguments(), "value", String.class, Secret::fromString);
+                                return ud.withArguments(newArguments);
+                            }
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
+            );
+        }
+
+        @NonNull
+        @Override
+        public UninstantiatedDescribable customUninstantiate(@NonNull UninstantiatedDescribable step) {
+            Map<String, Object> newStepArgs = copyMapReplacingEntry(step.getArguments(), "parameters", List.class, parameters -> parameters.stream()
+                    .map(parameter -> {
+                        if (parameter instanceof UninstantiatedDescribable) {
+                            UninstantiatedDescribable ud = (UninstantiatedDescribable) parameter;
+                            if (ud.getSymbol().equals("password")) {
+                                Map<String, Object> newParamArgs = copyMapReplacingEntry(ud.getArguments(), "value", Secret.class, Secret::getPlainText);
+                                return ud.withArguments(newParamArgs);
+                            }
+                        }
+                        return parameter;
+                    })
+                    .collect(Collectors.toList())
+            );
+            return step.withArguments(newStepArgs);
+        }
+
+        /**
+         * Copy a map, replacing the entry with the specified key if it matches the specified type.
+         */
+        private static <T> Map<String, Object> copyMapReplacingEntry(Map<String, ?> map, String keyToReplace, Class<T> requiredValueType, Function<T, Object> replacer) {
+            Map<String, Object> newMap = new HashMap<>();
+            for (Map.Entry<String, ?> entry : map.entrySet()) {
+                if (entry.getKey().equals(keyToReplace) && requiredValueType.isInstance(entry.getValue())) {
+                    newMap.put(entry.getKey(), replacer.apply(requiredValueType.cast(entry.getValue())));
+                } else {
+                    newMap.put(entry.getKey(), entry.getValue());
+                }
+            }
+            return newMap;
+        }
 
         @Override
-        public Step newInstance(@Nullable StaplerRequest req, @NonNull JSONObject formData) throws FormException {
-            return super.newInstance(req, formData);
+        public Set<? extends Class<?>> getRequiredContext() {
+            Set<Class<?>> context = new HashSet<>();
+            Collections.addAll(context, FlowNode.class, Run.class, TaskListener.class);
+            return Collections.unmodifiableSet(context);
         }
 
         @Override
@@ -89,6 +288,115 @@ public class BuildWithEiffelStep extends BuildTriggerStep {
         public String getDisplayName() {
             return "Build a job with custom Eiffel activity name";
         }
+
+        public AutoCompletionCandidates doAutoCompleteJob(@AncestorInPath ItemGroup<?> container, @QueryParameter final String value) {
+            // TODO remove code copy&pasted from AutoCompletionCandidates.ofJobNames when it supports testing outside Item bound
+            final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
+            class Visitor extends ItemVisitor {
+                String prefix;
+
+                Visitor(String prefix) {
+                    this.prefix = prefix;
+                }
+
+                @Override
+                public void onItem(Item i) {
+                    String n = contextualNameOf(i);
+                    if ((n.startsWith(value) || value.startsWith(n))
+                            // 'foobar' is a valid candidate if the current value is 'foo'.
+                            // Also, we need to visit 'foo' if the current value is 'foo/bar'
+                            && (value.length() > n.length() || !n.substring(value.length()).contains("/"))
+                            // but 'foobar/zot' isn't if the current value is 'foo'
+                            // we'll first show 'foobar' and then wait for the user to type '/' to show the rest
+                            && i.hasPermission(Item.READ)
+                        // and read permission required
+                    ) {
+                        if (i instanceof Queue.Task && n.startsWith(value))
+                            candidates.add(n);
+
+                        // recurse
+                        String oldPrefix = prefix;
+                        prefix = n;
+                        super.onItem(i);
+                        prefix = oldPrefix;
+                    }
+                }
+
+                private String contextualNameOf(Item i) {
+                    if (prefix.endsWith("/") || prefix.length() == 0)
+                        return prefix + i.getName();
+                    else
+                        return prefix + '/' + i.getName();
+                }
+            }
+
+            if (container == null || container == Jenkins.getInstanceOrNull()) {
+                new Visitor("").onItemGroup(Jenkins.getInstanceOrNull());
+            } else {
+                new Visitor("").onItemGroup(container);
+                if (value.startsWith("/"))
+                    new Visitor("/").onItemGroup(Jenkins.getInstanceOrNull());
+
+                for (StringBuilder p = new StringBuilder("../"); value.startsWith(p.toString()); p .append("../")) {
+                    container = ((Item) container).getParent();
+                    new Visitor(p.toString()).onItemGroup(container);
+                }
+            }
+            return candidates;
+            // END of copy&paste
+        }
+
+        @Restricted(DoNotUse.class) // for use from config.jelly
+        public String getContext() {
+            Job<?,?> job = StaplerReferer.findItemFromRequest(Job.class);
+            return job != null ? job.getFullName() : null;
+        }
+
+        @Restricted(DoNotUse.class) // for use from config.jelly
+        public String getContextEncoded() {
+            final String context = getContext();
+            //Functions.jsStringEscape() is also an alternative though the one below escapes more stuff
+            return context != null ? StringEscapeUtils.escapeJavaScript(context) : null;
+        }
+
+        public FormValidation doCheckPropagate(@QueryParameter boolean value, @QueryParameter boolean wait) {
+            if (!value && !wait) {
+                return FormValidation.warningWithMarkup(Messages.BuildWithEiffelStep_explicitly_disabling_both_propagate_and_wait());
+            }
+            return FormValidation.ok();
+        }
+
+        public FormValidation doCheckWait(@AncestorInPath ItemGroup<?> context, @QueryParameter boolean value, @QueryParameter String job) {
+            if (!value) {
+                return FormValidation.ok();
+            }
+            Item item = Jenkins.get().getItem(job, context, Item.class);
+            if (item == null) {
+                return FormValidation.ok();
+            }
+            if (item instanceof Job) {
+                return FormValidation.ok();
+            }
+            return FormValidation.error(Messages.BuildWithEiffelStep_no_wait_for_non_jobs());
+        }
+
+        public FormValidation doCheckJob(@AncestorInPath ItemGroup<?> context, @QueryParameter String value) {
+            if (StringUtils.isBlank(value)) {
+                return FormValidation.warning(Messages.BuildWithEiffelStep_no_job_configured());
+            }
+            Item item = Jenkins.get().getItem(value, context, Item.class);
+            if (item == null) {
+                return FormValidation.error(Messages.BuildWithEiffelStep_cannot_find(value));
+            }
+            if (item instanceof Queue.Task) {
+                return FormValidation.ok();
+            }
+            if (item instanceof Describable) {
+                return FormValidation.error(Messages.BuildWithEiffelStep_unsupported(((Describable<?>)item).getDescriptor().getDisplayName()));
+            }
+            return FormValidation.error(Messages.BuildWithEiffelStep_unsupported(item.getClass().getName()));
+        }
+
     }
 
     @Override

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Messages.properties
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/Messages.properties
@@ -21,7 +21,13 @@
 # THE SOFTWARE.
 
 # The following code is copied from https://github.com/jenkinsci/pipeline-build-step-plugin
-
+BuildWithEiffelStep.explicitly_disabling_both_propagate_and_wait=\
+    Explicitly disabling both <code>propagate</code> and <code>wait</code> is redundant, since <code>propagate</code> is ignored when <code>wait</code> is disabled. \
+    For brevity, leave <code>propagate</code> at its default.
+BuildWithEiffelStep.no_wait_for_non_jobs=Waiting for non-job items is not supported
+BuildWithEiffelStep.no_job_configured=No job configured
+BuildWithEiffelStep.cannot_find=No such job {0}
+BuildWithEiffelStep.unsupported=Building a {0} is not supported
 BuildWithEiffelStepExecution.building_=Building {0}
 BuildWithEiffelStepExecution.convertedParameterDescription=\
     {0} (Automatically converted to {1} because {2} passed the parameter using a different type)

--- a/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStep/help.html
+++ b/src/main/resources/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStep/help.html
@@ -1,6 +1,6 @@
 <div>
     <p>
-        Extension step of <a href="https://www.jenkins.io/doc/pipeline/steps/pipeline-build-step/">Build Step</a>
+        Modified copy of <a href="https://www.jenkins.io/doc/pipeline/steps/pipeline-build-step/">Build Step</a>
         to build a job with a custom Eiffel activity name.
     </p>
 </div>

--- a/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStepRegressionTest.java
+++ b/src/test/java/com/axis/jenkins/plugins/eiffel/eiffelbroadcaster/pipeline/build/BuildWithEiffelStepRegressionTest.java
@@ -3,8 +3,6 @@
 package com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.build;
 
 import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.Messages;
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.build.BuildWithEiffelStep;
-import com.axis.jenkins.plugins.eiffel.eiffelbroadcaster.pipeline.build.BuildWithEiffelStepExecution;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsParameterDefinition;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
@@ -693,7 +691,7 @@ public class BuildWithEiffelStepRegressionTest {
 
     @Test public void snippetizerRoundTrip() throws Exception {
         SnippetizerTester st = new SnippetizerTester(j);
-        BuildTriggerStep step = new BuildWithEiffelStep("downstream");
+        BuildWithEiffelStep step = new BuildWithEiffelStep("downstream");
         st.assertRoundTrip(step, "buildWithEiffel 'downstream'");
         step.setParameters(Arrays.asList(new StringParameterValue("branch", "default"), new BooleanParameterValue("correct", true)));
         // Note: This does not actually test the format of the JSON produced by the snippet generator for parameters, see generateSnippet* for tests of that behavior.


### PR DESCRIPTION
Resolves #118

Replaced inheritance of BuildTriggerStep and its descriptor with modified copied code from the class itself to avoid breaking the pipeline step document generator. Inheritance of a descriptor from another step is not supported by the generator and we might as well get rid off the Step inheritance to remove any dependencies towards BuildTriggerStep.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
